### PR TITLE
Accept valid checksum or CRC for device responses

### DIFF
--- a/msmart/base_command.py
+++ b/msmart/base_command.py
@@ -53,7 +53,7 @@ class command(ABC):
         frame = header + payload_crc
 
         # Calculate total frame checksum
-        frame.append(command.checksum(frame))
+        frame.append(command.checksum(frame[1:]))
 
         _LOGGER.debug("Frame data: {}".format(frame.hex()))
 
@@ -61,7 +61,7 @@ class command(ABC):
 
     @staticmethod
     def checksum(frame):
-        return (~sum(frame[1:]) + 1) & 0xFF
+        return (~sum(frame) + 1) & 0xFF
 
     @property
     def message_id(self):

--- a/msmart/device/AC/appliance.py
+++ b/msmart/device/AC/appliance.py
@@ -1,7 +1,7 @@
 
 from enum import IntEnum
 import logging
-from .command import ResponseId, response as base_response
+from .command import ResponseId, InvalidResponseException, response as base_response
 from .command import state_response, capabilities_response
 from .command import get_state_command, set_state_command, get_capabilities_command, toggle_display_command
 from msmart.device.base import device
@@ -139,10 +139,10 @@ class air_conditioning(device):
     def process_response(self, data):
         if super().process_response(data):
             # Construct response from data
-            response = base_response.construct(data)
-
-            # Ignore if no response
-            if response is None:
+            try:
+                response = base_response.construct(data)
+            except InvalidResponseException as e:
+                _LOGGER.error(e)
                 return
 
             self._support = True

--- a/msmart/device/AC/appliance.py
+++ b/msmart/device/AC/appliance.py
@@ -141,6 +141,10 @@ class air_conditioning(device):
             # Construct response from data
             response = base_response.construct(data)
 
+            # Ignore if no response
+            if response is None:
+                return
+
             self._support = True
 
             if response.id == ResponseId.State:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -453,6 +453,21 @@ class state_response(response):
     def __init__(self, frame: bytes):
         super().__init__(frame)
 
+        self.power_on = None
+        self.target_temperature = None
+        self.operational_mode = None
+        self.fan_speed = None
+        self.swing_mode = None
+        self.turbo_mode = None
+        self.eco_mode = None
+        self.sleep_mode = None
+        self.fahrenheit = None
+        self.indoor_temperature = None
+        self.outdoor_temperature = None
+        self.filter_alert = None
+        self.display_on = None
+        self.freeze_protection_mode = None
+
     def unpack(self, payload: memoryview):
         if self.id != ResponseId.State:
             # TODO throw instead?

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -527,8 +527,9 @@ class state_response(response):
 
         # TODO dudanov/MideaUART humidity set point in byte 19, mask 0x7F
 
-        # Some payloads are shorter than expected. Unsure what, when or why
-        if len(payload) < 22:  # TODO
+        # TODO Some payloads are shorter than expected. Unsure what, when or why
+        # This length was picked arbitrarily from one user's shorter payload
+        if len(payload) < 22:
             return
 
         self.freeze_protection_mode = bool(payload[21] & 0x80)

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -13,6 +13,10 @@ from msmart.base_command import command
 _LOGGER = logging.getLogger(__name__)
 
 
+class InvalidResponseException(Exception):
+    pass
+
+
 class ResponseId(IntEnum):
     State = 0xC0
     Capabilities = 0xB5
@@ -183,92 +187,71 @@ class toggle_display_command(command):
 
 class response():
     def __init__(self, payload: memoryview):
-        # Set ID and unpack
+        # Set ID and copy the payload
         self._id = payload[0]
-        self.unpack(payload)
-
-    @staticmethod
-    def validate(frame: memoryview):
-        # Validate frame checksum
-        calc_checksum = command.checksum(frame[1:-1])
-        recv_checksum = frame[-1]
-        if recv_checksum != calc_checksum:
-            _LOGGER.error("Frame '{}' failed checksum. Received: 0x{:X}, Expected: 0x{:X}.".format(
-                frame.hex(), recv_checksum, calc_checksum))
-            return None
-
-        # Fetch frame payload and payload with CRC
-        payload_crc = frame[10:-1]
-        payload = payload_crc[0:-1]
-
-        # Validate payload CRC
-        calc_crc = crc8.calculate(payload)
-        recv_crc = payload_crc[-1]
-
-        # Some device seem to use a 2nd checksum over the payload instead of a CRC
-        payload_checksum = command.checksum(payload)
-
-        if recv_crc == calc_crc or recv_crc == payload_checksum:
-            return payload
-
-        _LOGGER.error("Payload '{}' failed CRC and checksum. Received: 0x{:X}, Expected: 0x{:X} or 0x{:X}.".format(
-            payload_crc.hex(), recv_crc, calc_crc, payload_checksum))
-
-        return None
-
-    @staticmethod
-    def construct(frame: bytes):
-        # Build a memoryview of the frame for zero-copy slicing
-        frame_mv = memoryview(frame)
-
-        payload = response.validate(frame_mv)
-        if not payload:
-            return None
-
-        id = payload[0]
-        if id == ResponseId.State:
-            resp = state_response(payload)
-        elif id == ResponseId.Capabilities:
-            resp = capabilities_response(payload)
-        else:
-            # Unrecognized frame
-            resp = response(payload)
-
-        frame_mv.release()
-        return resp
+        self._payload = bytes(payload)
 
     @property
     def id(self):
         return self._id
 
-    @abstractmethod
-    def unpack(self, payload: memoryview):
-        # Make a copy for debug
-        self.payload = bytes(payload)
+    @property
+    def payload(self):
+        return self._payload
+
+    @staticmethod
+    def validate(frame: memoryview):
+        # Validate frame checksum
+        frame_checksum = command.checksum(frame[1:-1])
+        if frame_checksum != frame[-1]:
+            raise InvalidResponseException(
+                f"Frame '{frame.hex()}' failed checksum. Received: 0x{frame[-1]:X}, Expected: 0x{frame_checksum:X}.")
+
+        # Extract frame payload to validate CRC/checksum
+        payload = frame[10:-1]
+
+        # Some devices use a CRC others seem to use a 2nd checksum
+        payload_crc = crc8.calculate(payload[0:-1])
+        payload_checksum = command.checksum(payload[0:-1])
+
+        if payload_crc != payload[-1] and payload_checksum != payload[-1]:
+            raise InvalidResponseException(
+                f"Payload '{payload.hex()}' failed CRC and checksum. Received: 0x{payload[-1]:X}, Expected: 0x{payload_crc:X} or 0x{payload_checksum:X}.")
+
+    @staticmethod
+    def construct(frame: bytes):
+        # Build a memoryview of the frame for zero-copy slicing
+        with memoryview(frame) as frame_mv:
+            # Ensure frame is valid before parsing
+            response.validate(frame_mv)
+
+            # Parse frame depending on id
+            id = frame_mv[10]
+            payload = frame_mv[10:-2]
+            if id == ResponseId.State:
+                return state_response(payload)
+            elif id == ResponseId.Capabilities:
+                return capabilities_response(payload)
+            else:
+                return response(payload)
 
 
 class capabilities_response(response):
-    def __init__(self, frame: bytes):
-        super().__init__(frame)
+    def __init__(self, payload: memoryview):
+        super().__init__(payload)
 
-    def unpack(self, payload: memoryview):
-        if self.id != ResponseId.Capabilities:
-            # TODO throw instead?
-            _LOGGER.error(
-                "Invalid capabilities response ID.")
-            return
+        self._capabilities = {}
 
         _LOGGER.debug(
             "Capabilities response payload: {}".format(payload.hex()))
 
-        self.read_capabilities(payload)
+        self._parse_capabilities(payload)
 
-        _LOGGER.debug(
-            "Supported capabilities: {}".format(self.capabilities))
+        _LOGGER.debug("Supported capabilities: {}".format(self._capabilities))
 
-    def read_capabilities(self, payload: memoryview):
+    def _parse_capabilities(self, payload: memoryview):
         # Clear existing capabilities
-        self.capabilities = {}
+        self._capabilities.clear()
 
         # Define some local functions to parse capability values
         def get_bool(v): return v != 0
@@ -368,24 +351,24 @@ class capabilities_response(response):
                 if isinstance(reader, list):
                     # Apply each reader in the list
                     for r in reader:
-                        self.capabilities.update(apply(r))
+                        self._capabilities.update(apply(r))
                 else:
                     # Apply the single reader
-                    self.capabilities.update(apply(reader))
+                    self._capabilities.update(apply(reader))
 
             elif id == CapabilityId.Temperatures:
                 # Skip if capability size is too small
                 if size < 6:
                     continue
 
-                self.capabilities["cool_min_temperature"] = caps[3] * 0.5
-                self.capabilities["cool_max_temperature"] = caps[4] * 0.5
-                self.capabilities["auto_min_temperature"] = caps[5] * 0.5
-                self.capabilities["auto_max_temperature"] = caps[6] * 0.5
-                self.capabilities["heat_min_temperature"] = caps[7] * 0.5
-                self.capabilities["heat_max_temperature"] = caps[8] * 0.5
+                self._capabilities["cool_min_temperature"] = caps[3] * 0.5
+                self._capabilities["cool_max_temperature"] = caps[4] * 0.5
+                self._capabilities["auto_min_temperature"] = caps[5] * 0.5
+                self._capabilities["auto_max_temperature"] = caps[6] * 0.5
+                self._capabilities["heat_min_temperature"] = caps[7] * 0.5
+                self._capabilities["heat_max_temperature"] = caps[8] * 0.5
 
-                self.capabilities["decimals"] = caps[9] == 0 if size > 6 else caps[2] == 0
+                self._capabilities["decimals"] = caps[9] == 0 if size > 6 else caps[2] == 0
 
             else:
                 _LOGGER.warn(
@@ -396,11 +379,11 @@ class capabilities_response(response):
 
     @property
     def swing_horizontal(self):
-        return self.capabilities.get("swing_horizontal", False)
+        return self._capabilities.get("swing_horizontal", False)
 
     @property
     def swing_vertical(self):
-        return self.capabilities.get("swing_vertical", False)
+        return self._capabilities.get("swing_vertical", False)
 
     @property
     def swing_both(self):
@@ -408,50 +391,51 @@ class capabilities_response(response):
 
     @property
     def dry_mode(self):
-        return self.capabilities.get("dry_mode", False)
+        return self._capabilities.get("dry_mode", False)
 
     @property
     def cool_mode(self):
-        return self.capabilities.get("cool_mode", False)
+        return self._capabilities.get("cool_mode", False)
 
     @property
     def heat_mode(self):
-        return self.capabilities.get("heat_mode", False)
+        return self._capabilities.get("heat_mode", False)
 
     @property
     def auto_mode(self):
-        return self.capabilities.get("auto_mode", False)
+        return self._capabilities.get("auto_mode", False)
 
     @property
     def eco_mode(self):
-        return self.capabilities.get("eco_mode", False) or self.capabilities.get("eco_mode_2", False)
+        return self._capabilities.get("eco_mode", False) or self._capabilities.get("eco_mode_2", False)
 
     @property
     def turbo_mode(self):
-        return self.capabilities.get("turbo_heat", False) or self.capabilities.get("turbo_cool", False)
+        return self._capabilities.get("turbo_heat", False) or self._capabilities.get("turbo_cool", False)
 
     @property
     def display_control(self):
-        return self.capabilities.get("light_control", False)
+        return self._capabilities.get("light_control", False)
 
     @property
     def min_temperature(self):
         mode = ["cool", "auto", "heat"]
-        return min([self.capabilities.get(f"{m}_min_temperature", 16) for m in mode])
+        return min([self._capabilities.get(f"{m}_min_temperature", 16) for m in mode])
 
     @property
     def max_temperature(self):
         mode = ["cool", "auto", "heat"]
-        return max([self.capabilities.get(f"{m}_max_temperature", 30) for m in mode])
+        return max([self._capabilities.get(f"{m}_max_temperature", 30) for m in mode])
 
     @property
     def freeze_protection_mode(self):
-        return self.capabilities.get("freeze_protection", False)
+        return self._capabilities.get("freeze_protection", False)
 
 
 class state_response(response):
-    def __init__(self, frame: bytes):
-        # Ensure attributes exist
+    def __init__(self, payload: memoryview):
+        super().__init__(payload)
+
         self.power_on = None
         self.target_temperature = None
         self.operational_mode = None
@@ -466,24 +450,12 @@ class state_response(response):
         self.filter_alert = None
         self.display_on = None
         self.freeze_protection_mode = None
-    
-        # Call super's init now to unpack the data
-        # TODO this feels like a hack
-        super().__init__(frame)
 
-    def unpack(self, payload: memoryview):
-        if self.id != ResponseId.State:
-            # TODO throw instead?
-            _LOGGER.error(
-                "Invalid state response ID.")
-            return
+        _LOGGER.debug("State response payload: {}".format(payload.hex()))
 
-        _LOGGER.debug(
-            "State response payload: {}".format(payload.hex()))
+        self._parse(payload)
 
-        self.read_state(payload)
-
-    def read_state(self, payload: memoryview):
+    def _parse(self, payload: memoryview):
 
         self.power_on = bool(payload[1] & 0x1)
         # self.imode_resume = payload[1] & 0x4

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -451,8 +451,7 @@ class capabilities_response(response):
 
 class state_response(response):
     def __init__(self, frame: bytes):
-        super().__init__(frame)
-
+        # Ensure attributes exist
         self.power_on = None
         self.target_temperature = None
         self.operational_mode = None
@@ -467,6 +466,10 @@ class state_response(response):
         self.filter_alert = None
         self.display_on = None
         self.freeze_protection_mode = None
+    
+        # Call super's init now to unpack the data
+        # TODO this feels like a hack
+        super().__init__(frame)
 
     def unpack(self, payload: memoryview):
         if self.id != ResponseId.State:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1,0 +1,23 @@
+import unittest
+from .command import response
+
+TEST_MESSAGE_CHECKSUM_AS_CRC = bytes.fromhex("aa1eac00000000000003c0004b1e7f7f000000000069630000000000000d33")
+TEST_MESSAGE_V2 = bytes.fromhex("aa22ac00000000000303c0014566000000300010045eff00000000000000000069fdb9")
+TEST_MESSAGE_V3 = bytes.fromhex("aa23ac00000000000303c00145660000003c0010045c6b20000000000000000000020d79")
+
+class TestResponse(unittest.TestCase):
+
+    def test_checksum_as_crc(self):
+        resp = response.construct(TEST_MESSAGE_CHECKSUM_AS_CRC)
+        self.assertIsNotNone(resp)
+
+    def test_v2_response(self):
+        resp = response.construct(TEST_MESSAGE_V2)
+        self.assertIsNotNone(resp)
+
+    def test_v3_response(self):
+        resp = response.construct(TEST_MESSAGE_V3)
+        self.assertIsNotNone(resp)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -36,15 +36,28 @@ class TestStateResponse(unittest.TestCase):
     def _test_response(self, msg):
         resp = self._test_build_response(msg)
         self._test_check_attributes(resp)
+        return resp
 
     def test_message_checksum(self):
-        self._test_response(TEST_MESSAGE_CHECKSUM_AS_CRC)
+        resp = self._test_response(TEST_MESSAGE_CHECKSUM_AS_CRC)
+
+        self.assertEqual(resp.target_temperature, 27.0)
+        self.assertEqual(resp.indoor_temperature, 27.5)
+        self.assertEqual(resp.outdoor_temperature, 24.5)
 
     def test_message_v2(self):
-        self._test_response(TEST_MESSAGE_V2)
+        resp = self._test_response(TEST_MESSAGE_V2)
+
+        self.assertEqual(resp.target_temperature, 21.0)
+        self.assertEqual(resp.indoor_temperature, 22.0)
+        self.assertEqual(resp.outdoor_temperature, None)
 
     def test_message_v3(self):
-        self._test_response(TEST_MESSAGE_V3)
+        resp = self._test_response(TEST_MESSAGE_V3)
+
+        self.assertEqual(resp.target_temperature, 21.0)
+        self.assertEqual(resp.indoor_temperature, 21.0)
+        self.assertEqual(resp.outdoor_temperature, 28.5)
 
 
 if __name__ == '__main__':

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1,23 +1,51 @@
 import unittest
 from .command import response
 
-TEST_MESSAGE_CHECKSUM_AS_CRC = bytes.fromhex("aa1eac00000000000003c0004b1e7f7f000000000069630000000000000d33")
-TEST_MESSAGE_V2 = bytes.fromhex("aa22ac00000000000303c0014566000000300010045eff00000000000000000069fdb9")
-TEST_MESSAGE_V3 = bytes.fromhex("aa23ac00000000000303c00145660000003c0010045c6b20000000000000000000020d79")
+# V3 state response with checksum as CRC, and shorter than expected
+TEST_MESSAGE_CHECKSUM_AS_CRC = bytes.fromhex(
+    "aa1eac00000000000003c0004b1e7f7f000000000069630000000000000d33")
+# V2 state response
+TEST_MESSAGE_V2 = bytes.fromhex(
+    "aa22ac00000000000303c0014566000000300010045eff00000000000000000069fdb9")
+# V3 state response
+TEST_MESSAGE_V3 = bytes.fromhex(
+    "aa23ac00000000000303c00145660000003c0010045c6b20000000000000000000020d79")
 
-class TestResponse(unittest.TestCase):
 
-    def test_checksum_as_crc(self):
-        resp = response.construct(TEST_MESSAGE_CHECKSUM_AS_CRC)
+class TestStateResponse(unittest.TestCase):
+    def assertHasAttr(self, obj, attr):
+        """Assert that the supplied object has the supplied attribute."""
+        self.assertTrue(hasattr(obj, attr),
+                        msg=f"Object {obj} lacks attribute '{attr}'.")
+
+    def _test_build_response(self, msg):
+        resp = response.construct(msg)
         self.assertIsNotNone(resp)
 
-    def test_v2_response(self):
-        resp = response.construct(TEST_MESSAGE_V2)
-        self.assertIsNotNone(resp)
+        return resp
 
-    def test_v3_response(self):
-        resp = response.construct(TEST_MESSAGE_V3)
-        self.assertIsNotNone(resp)
+    def _test_check_attributes(self, resp):
+        expected_attrs = ["power_on", "target_temperature", "operational_mode",
+                          "fan_speed", "swing_mode", "turbo_mode", "eco_mode",
+                          "sleep_mode", "fahrenheit", "indoor_temperature",
+                          "outdoor_temperature", "filter_alert", "display_on",
+                          "freeze_protection_mode"]
+        for attr in expected_attrs:
+            self.assertHasAttr(resp, attr)
+
+    def _test_response(self, msg):
+        resp = self._test_build_response(msg)
+        self._test_check_attributes(resp)
+
+    def test_message_checksum(self):
+        self._test_response(TEST_MESSAGE_CHECKSUM_AS_CRC)
+
+    def test_message_v2(self):
+        self._test_response(TEST_MESSAGE_V2)
+
+    def test_message_v3(self):
+        self._test_response(TEST_MESSAGE_V3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows a response through if either a CRC or checksum matches. Some devices appear to protect the response payload with a 2nd checksum instead of a CRC8. See issue #9 for related reports.

Additionally this PR
* Add some unit tests for response parsing
* Fixes an uncaught exception when trying to access the response ID field after failing to parse
* Fixes some lint issues with the response classes
* Restructures the response parsing.

Close #9  and close mill1000/midea-ac-py#11