### PR TITLE
Supress logger messages of failed authentications during discovery

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -31,13 +31,15 @@ class Device():
     async def apply(self):
         raise NotImplementedError()
 
-    async def authenticate(self, token: Token, key: Key) -> bool:
+    async def authenticate(self, token: Token, key: Key, *, silent=False) -> bool:
         """Authenticate with a V3 device."""
         try:
             await self._lan.authenticate(token, key)
             return True
         except (AuthenticationError, TimeoutError) as e:
-            _LOGGER.error("Authentication failed. Error: %s", e)
+            # TODO feels like a hack, should we make caller try/except instead?
+            if not silent:
+                _LOGGER.error("Authentication failed. Error: %s", e)
             return False
 
     async def send_command(self, command: Command) -> Optional[List[bytes]]:

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -374,7 +374,7 @@ class Discover:
                 _LOGGER.error(e)
                 continue
 
-            if await dev.authenticate(token, key):
+            if await dev.authenticate(token, key, silent=True):
                 return True
 
         return False


### PR DESCRIPTION
During discovery it is expected (for reasons) that some authentication attempts may fail. Currently this causes an error message to be emitted.

This PR adds a (hacky) option to silence log reports from the device's `authenticate` method. Close mill1000/midea-ac-py/issues/23