### PR TITLE
Catch NotImplementedError when connecting to device during discovery

### DIFF
--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -410,6 +410,12 @@ class Discover:
             if not success:
                 return False
 
-        await dev.refresh()
+        # Attempt to refresh the device state
+        try:
+            await dev.refresh()
+        except NotImplementedError:
+            _LOGGER.error(
+                "Device class %s has not implemented refresh().", type(dev).__name__)
+            return False
 
         return True


### PR DESCRIPTION
Fixes an uncaught exception if a user has an unsupported device during discovery. Currently the an instance of the base device class is created which does not support refresh() or update() methods.

This should let us more gracefully fail discovery when unsupported devices are present. The logger will report an error and HA users will get a message about being unable to connect.