### PR TITLE
Add a timeout to LAN connect calls

### DIFF
--- a/msmart/lan.py
+++ b/msmart/lan.py
@@ -420,8 +420,12 @@ class LAN:
 
         # TODO throws OSError and ???
         loop = asyncio.get_event_loop()
-        _transport, protocol = await loop.create_connection(
+        task = loop.create_connection(
             lambda: protocol_class(), self._ip, self._port)  # pylint: disable=unnecessary-lambda
+        try:
+            _transport, protocol = await asyncio.wait_for(task, timeout=5)
+        except (TimeoutError, asyncio.TimeoutError) as e:
+            raise TimeoutError("Connect timeout.") from e
 
         if self._protocol_version == 3:
             self._protocol = cast(_LanProtocolV3, protocol)


### PR DESCRIPTION
Add a timeout to LAN modules `_connect` calls. The current timeout is approximately 2 minutes which must be OS dependent. This implements a significantly shorter timeout of 5 seconds.