### PR TITLE
Add a check for the legacy msmart package on import

### DIFF
--- a/msmart/__init__.py
+++ b/msmart/__init__.py
@@ -1,3 +1,11 @@
 from importlib import metadata
 
 __version__ = metadata.version("msmart-ng")
+
+# Guard against legacy msmart package which may cause conflicts
+try:
+    metadata.version("msmart")
+    raise ImportError("Legacy msmart packaged detected. Please remove.")
+except metadata.PackageNotFoundError:
+    # Good, legacy package is missing
+    pass


### PR DESCRIPTION
Try to fail more obviously on systems that have conflicting packages