### PR TITLE
Add ability to limit maximum connection lifetime

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -71,6 +71,10 @@ class Device():
                 _LOGGER.error("Authentication failed. Error: %s", e)
             return False
 
+    def set_max_connection_lifetime(self, seconds: Optional[int]) -> None:
+        """Set the maximum connection lifetime of the LAN protocol."""
+        self._lan.max_connection_lifetime = seconds
+
     @property
     def ip(self) -> str:
         return self._ip

--- a/msmart/lan.py
+++ b/msmart/lan.py
@@ -446,7 +446,7 @@ class LAN:
         if self._max_connection_lifetime is None:
             return None
 
-        return self._max_connection_lifetime.total_seconds()
+        return int(self._max_connection_lifetime.total_seconds())
 
     @max_connection_lifetime.setter
     def max_connection_lifetime(self, seconds: Optional[int]) -> None:

--- a/msmart/lan.py
+++ b/msmart/lan.py
@@ -428,7 +428,9 @@ class LAN:
         self._key = None
         self._protocol_version = 2
         self._protocol = None
+
         self._connection_expiration = None
+        self._max_connection_lifetime = None
 
     @property
     def token(self) -> Optional[bytes]:
@@ -437,6 +439,20 @@ class LAN:
     @property
     def key(self) -> Optional[bytes]:
         return self._key
+
+    @property
+    def max_connection_lifetime(self) -> Optional[int]:
+        """Get the maximum connection lifetime in seconds."""
+        if self._max_connection_lifetime is None:
+            return None
+
+        return self._max_connection_lifetime.total_seconds()
+
+    @max_connection_lifetime.setter
+    def max_connection_lifetime(self, seconds: Optional[int]) -> None:
+        """Set the maximum connection lifetime in seconds."""
+        self._max_connection_lifetime = None if seconds is None else timedelta(
+            seconds=seconds)
 
     @property
     def _alive(self) -> bool:
@@ -468,7 +484,8 @@ class LAN:
 
         self._protocol = protocol
 
-        self._connection_expiration = datetime.utcnow() + timedelta(seconds=90)
+        if self._max_connection_lifetime:
+            self._connection_expiration = datetime.utcnow() + self._max_connection_lifetime
 
     def _disconnect(self) -> None:
         if self._protocol:

--- a/msmart/lan.py
+++ b/msmart/lan.py
@@ -140,6 +140,8 @@ class _LanProtocol(asyncio.Protocol):
 class _LanProtocolV3(_LanProtocol):
     """Midea LAN protocol V3."""
 
+    AUTHENTICATION_EXPIRATION = timedelta(hours=12)
+
     class PacketType(IntEnum):
         HANDSHAKE_REQUEST = 0x0
         HANDSHAKE_RESPONSE = 0x1
@@ -173,14 +175,14 @@ class _LanProtocolV3(_LanProtocol):
         self._packet_id = 0
         self._buffer = bytearray(0)
         self._local_key = None
+        self._local_key_expiration = None
 
     @property
-    def local_key(self) -> Optional[bytes]:
-        return self._local_key
+    def authenticated(self) -> bool:
+        if self._protocol.local_key is None or self._protocol.local_key_expiration is None:
+            return False
 
-    @local_key.setter
-    def local_key(self, key: bytes) -> None:
-        self._local_key = key
+        return datetime.utcnow() < self._protocol.local_key_expiration
 
     def data_received(self, data: bytes) -> None:
         """Handle data received events."""
@@ -383,7 +385,7 @@ class _LanProtocolV3(_LanProtocol):
         # Construct the local key
         return strxor(decrypted_payload, key)
 
-    async def authenticate(self, token: Optional[bytes], key: Optional[bytes]) -> bytes:
+    async def authenticate(self, token: Optional[bytes], key: Optional[bytes]) -> None:
 
         # Raise an exception if trying to auth without any token or key
         if not token or not key:
@@ -401,14 +403,17 @@ class _LanProtocolV3(_LanProtocol):
 
         # Generate local key from cloud key
         with memoryview(response) as response_mv:
-            key = self._get_local_key(key, response_mv)
+            self._local_key = self._get_local_key(key, response_mv)
 
-        return key
+        # Set expiration time
+        self._local_key_expiration = datetime.utcnow() + self.AUTHENTICATION_EXPIRATION
+
+        _LOGGER.info("Authentication successful. Expiration: %s, Local key: %s",
+                     self._local_key_expiration.isoformat(timespec="seconds"), self._local_key.hex())
 
 
 class LAN:
     RETRIES = 3
-    AUTHENTICATION_EXPIRATION = timedelta(hours=12)
 
     def __init__(self, ip: str, port: int, device_id: int) -> None:
         self._ip = ip
@@ -419,8 +424,6 @@ class LAN:
         self._key = None
         self._protocol_version = 2
         self._protocol = None
-        self._auth_local_key = None
-        self._auth_expiration = None
 
     @property
     def token(self) -> Optional[bytes]:
@@ -460,10 +463,6 @@ class LAN:
             self._protocol.disconnect()
             self._protocol = None
 
-        # Clear auth info to force reauth
-        self._auth_local_key = None
-        self._auth_expiration = None
-
     async def authenticate(self, token: Token = None, key: Key = None, retries: int = RETRIES) -> None:
         """Authenticate against a V3 device. Use cached token and key unless provided a new token and key."""
 
@@ -494,7 +493,7 @@ class LAN:
         # Attempt to authenticate
         while retries > 0:
             try:
-                self._auth_local_key = await self._protocol.authenticate(token, key)
+                await self._protocol.authenticate(token, key)
                 break
             except (TimeoutError, asyncio.TimeoutError) as e:
                 if retries > 1:
@@ -503,14 +502,8 @@ class LAN:
                 else:
                     raise TimeoutError("No response from host.") from e
 
-        # A local key should exist now
-        assert self._auth_local_key is not None
-
-        # Set expiration time
-        self._auth_expiration = datetime.utcnow() + self.AUTHENTICATION_EXPIRATION
-
-        _LOGGER.info("Authentication successful. Expiration: %s, Local key: %s",
-                     self._auth_expiration.isoformat(timespec="seconds"), self._auth_local_key.hex())
+        # Protocol should be authenticated by now
+        assert self._protocol.authenticated
 
         # Update stored token and key if successful
         self._token = token
@@ -558,17 +551,12 @@ class LAN:
         assert self._protocol is not None
 
         # Authenticate as needed
-        if isinstance(self._protocol, _LanProtocolV3):
-            # Authorize if key is invalid or expired
-            if (self._auth_local_key is None or self._auth_expiration is None
-                    or datetime.utcnow() > self._auth_expiration):
-                await self.authenticate()
+        if (isinstance(self._protocol, _LanProtocolV3)
+                and not self._protocol.authenticated):
+            await self.authenticate()
 
-            # A local auth key should exist now
-            assert self._auth_local_key is not None
-
-           # Set key in protocol
-            self._protocol.local_key = self._auth_local_key
+            # Protocol should be authenticated now
+            assert self._protocol.authenticated
 
         # Encode frame to packet
         packet = _Packet.encode(self._device_id, data)


### PR DESCRIPTION
Add hooks to Device and LAN classes to enable specifying a maximum connection lifetime. Device connections will automatically be re-established whenever a connection is older than this limit.

Hopefully address https://github.com/mill1000/midea-ac-py/issues/30