### PR TITLE
Fix supported fan speeds when no fan speed capability is received

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -428,32 +428,36 @@ class CapabilitiesResponse(Response):
             # Advanced to next capability
             caps = caps[3+size:]
 
+    def _get_fan_speed(self, speed) -> bool:
+        # If any fan_ capability was received, check against them
+        if any(k.startswith("fan_") for k in self._capabilities):
+            # Assume that a fan capable of custom speeds is capable of any speed
+            return self._capabilities.get(f"fan_{speed}", False) or self._capabilities.get("fan_custom", False)
+
+        # Otherwise return a default set for devices that don't send the capability
+        return speed in ["low", "medium", "high", "auto"]
+
     # TODO rethink these properties for fan speed, operation mode and swing mode
     # Surely there's a better way than define props for each possible cap
     @property
     def fan_silent(self) -> bool:
-        # Assume that a fan capable of custom speeds is capable of any speed
-        return self._capabilities.get("fan_silent", False) or self._capabilities.get("fan_custom", False)
+        return self._get_fan_speed("silent")
 
     @property
     def fan_low(self) -> bool:
-        # Assume that a fan capable of custom speeds is capable of any speed
-        return self._capabilities.get("fan_low", False) or self._capabilities.get("fan_custom", False)
+        return self._get_fan_speed("low")
 
     @property
     def fan_medium(self) -> bool:
-        # Assume that a fan capable of custom speeds is capable of any speed
-        return self._capabilities.get("fan_medium", False) or self._capabilities.get("fan_custom", False)
+        return self._get_fan_speed("medium")
 
     @property
     def fan_high(self) -> bool:
-        # Assume that a fan capable of custom speeds is capable of any speed
-        return self._capabilities.get("fan_high", False) or self._capabilities.get("fan_custom", False)
+        return self._get_fan_speed("high")
 
     @property
     def fan_auto(self) -> bool:
-        # Assume that a fan capable of custom speeds is capable of any speed
-        return self._capabilities.get("fan_auto", False) or self._capabilities.get("fan_custom", False)
+        return self._get_fan_speed("auto")
 
     @property
     def fan_custom(self) -> bool:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -210,6 +210,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
     def test_capabilities(self) -> None:
         """Test that we decode capabilities responses as expected."""
         # https://github.com/mill1000/midea-ac-py/issues/13#issuecomment-1657485359
+        # Identical payload received in https://github.com/mill1000/midea-msmart/issues/88#issuecomment-1781972832
 
         TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
             "aa29ac00000000000303b5071202010113020101140201011502010116020101170201001a020101dedb")
@@ -233,8 +234,8 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "swing_horizontal": True, "swing_vertical": True, "swing_both": True,
             "dry_mode": True, "heat_mode": True, "cool_mode": True, "auto_mode": True,
             "eco_mode": True, "turbo_mode": True, "freeze_protection_mode": True,
-            "fan_custom": False, "fan_silent": False, "fan_low": False,
-            "fan_medium": False,  "fan_high": False, "fan_auto": False,
+            "fan_custom": False, "fan_silent": False, "fan_low": True,
+            "fan_medium": True,  "fan_high": True, "fan_auto": True,
             "min_temperature": 16, "max_temperature": 30,
             "display_control": False, "filter_reminder": False
         }


### PR DESCRIPTION
Report a default set of fan supported speeds (Low, Medium, High, Auto) when no specific fan speed capability is received.

Close #88