### PR TITLE
Implement support for "Follow Me" feature

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -127,6 +127,7 @@ class SetStateCommand(Command):
         self.fahrenheit = True
         self.sleep_mode = False
         self.freeze_protection_mode = False
+        self.follow_me = False
 
     @property
     def payload(self) -> bytes:
@@ -166,6 +167,7 @@ class SetStateCommand(Command):
 
         # Build alternate turbo byte
         turbo_alt = 0x20 if self.turbo_mode else 0
+        follow_me = 0x80 if self.follow_me else 0
 
         # Build alternate turbo byte
         freeze_protect = 0x80 if self.freeze_protection_mode else 0
@@ -183,8 +185,8 @@ class SetStateCommand(Command):
             0x7F, 0x7F, 0x00,
             # Swing mode
             swing_mode,
-            # Alternate turbo mode
-            turbo_alt,
+            # Follow me amd alternate turbo mode
+            follow_me | turbo_alt,
             # ECO mode
             eco_mode,
             # Sleep mode, turbo mode and fahrenheit
@@ -537,6 +539,7 @@ class StateResponse(Response):
         self.filter_alert = None
         self.display_on = None
         self.freeze_protection_mode = None
+        self.follow_me = None
 
         _LOGGER.debug("State response payload: %s", payload.hex())
 
@@ -582,7 +585,7 @@ class StateResponse(Response):
         # self.save = (payload[8] & 0x08) > 0
         # self.low_frequency_fan = (payload[8] & 0x10) > 0
         self.turbo_mode = bool(payload[8] & 0x20)
-        # self.feel_own = (payload[8] & 0x80) > 0
+        self.follow_me = bool(payload[8] & 0x80)
 
         self.eco_mode = bool(payload[9] & 0x10)
         # self.child_sleep_mode = (payload[9] & 0x01) > 0

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -108,6 +108,7 @@ class AirConditioner(Device):
         self._fahrenheit_unit = False  # Display temperature in Fahrenheit
         self._display_on = False
         self._filter_alert = False
+        self._follow_me = False
 
         # Support all known modes initially
         self._supported_op_modes = cast(
@@ -163,6 +164,8 @@ class AirConditioner(Device):
         self._fahrenheit_unit = res.fahrenheit
 
         self._filter_alert = res.filter_alert
+
+        self._follow_me = res.follow_me
 
         # self._on_timer = res.on_timer
         # self._off_timer = res.off_timer
@@ -319,6 +322,7 @@ class AirConditioner(Device):
                 self._freeze_protection_mode, False)
             cmd.sleep_mode = or_default(self._sleep_mode, False)
             cmd.fahrenheit = or_default(self._fahrenheit_unit, False)
+            cmd.follow_me = or_default(self._follow_me, False)
 
             await self._send_command(cmd, self._defer_update)
         finally:
@@ -477,6 +481,16 @@ class AirConditioner(Device):
         self._fahrenheit_unit = enabled
 
     @property
+    def follow_me(self) -> Optional[bool]:
+        return self._follow_me
+
+    @follow_me.setter
+    def follow_me(self, enabled: bool) -> None:
+        if self._updating:
+            self._defer_update = True
+        self._follow_me = enabled
+
+    @property
     def display_on(self) -> Optional[bool]:
         return self._display_on
 
@@ -521,6 +535,7 @@ class AirConditioner(Device):
             "turbo": self.turbo_mode,
             "freeze_protection": self.freeze_protection_mode,
             "sleep": self.sleep_mode,
+            "follow_me": self.follow_me,
             "display_on": self.display_on,
             "beep": self.beep,
             "fahrenheit": self.fahrenheit,


### PR DESCRIPTION
Adds support for the "follow me" feature which allows the AC unit to receive temperature readings from the remote control.

From Midea's technology page
![image](https://github.com/mill1000/midea-msmart/assets/6924622/2f103534-4309-478b-9bb1-6e7c476134a6)

For this function to work
1. The remote control must be in range, and in line of sight of the AC unit
2. The remote control must manually be put in "follow me" mode so it sends temperature readings. It may be possible to leave this remote continuously in this mode, although battery life will likely decrease.

Close #89 

Other references may refer to this function as "feel own",  "personal feeling", "body sense" or "remote sense".
