### PR TITLE
Pin Alpine version in Dockerfile to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN python -m build
 
 # Production step
 # Using base alpine package so we can utilize pycryptodome in package repo
-FROM alpine:latest
+FROM alpine:3.18
 RUN apk add --update python3 py3-pip py3-pycryptodome
 COPY --from=build /msmart-build/dist/msmart_ng-*.whl /tmp
 RUN pip install /tmp/msmart_ng-*.whl


### PR DESCRIPTION
Alpine 3.19 switched to a externally managed pip environment which makes package installation difficult.

Originally attempted to resolve this with pipx in #101, but the builds failed on ARM targets as the pycryptodome dependency needs to be built from source.