### PR TITLE
Fix warnings from setuptools when packaging project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ midea-discover = "msmart.cli:_legacy_main"
 msmart-ng = "msmart.cli:main"
 
 [tool.setuptools]
-packages=["msmart"]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["msmart", "msmart.*"]
+exclude = ["msmart.tests"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Setuptools was complaining about an ambiguous configuration because the submodule in msmart were not explicitly included in the packages option.


As a side note, I find it odd that's it's so particularly difficult to tell setuptools to only package a single folder.