### PR TITLE
Change HIGH fan speed value to 80

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -43,7 +43,7 @@ class AirConditioner(Device):
 
     class FanSpeed(IntEnumHelper):
         AUTO = 102
-        HIGH = 100
+        HIGH = 80
         MEDIUM = 60
         LOW = 40
         SILENT = 20


### PR DESCRIPTION
Close #95, and also https://github.com/mill1000/midea-ac-py/issues/67

Waiting on confirmation from another user that their system uses 80 (0x50) as a high fan speed