### PR TITLE
Throw exceptions on authentication failures

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -60,16 +60,12 @@ class Device():
     async def apply(self) -> None:
         raise NotImplementedError()
 
-    async def authenticate(self, token: Token, key: Key, *, silent=False) -> bool:
+    async def authenticate(self, token: Token, key: Key) -> None:
         """Authenticate with a V3 device."""
         try:
             await self._lan.authenticate(token, key)
-            return True
-        except (AuthenticationError, TimeoutError) as e:
-            # TODO feels like a hack, should we make caller try/except instead?
-            if not silent:
-                _LOGGER.error("Authentication failed. Error: %s", e)
-            return False
+        except (ProtocolError, TimeoutError) as e:
+            raise AuthenticationError(e) from e
 
     def set_max_connection_lifetime(self, seconds: Optional[int]) -> None:
         """Set the maximum connection lifetime of the LAN protocol."""

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -8,6 +8,7 @@ from msmart.cloud import Cloud, CloudError
 from msmart.const import OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
+from msmart.lan import AuthenticationError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,11 @@ async def _query(args) -> None:
         # Manually create device and authenticate
         device = AC(ip=args.host, port=6444, device_id=args.device_id)
         if args.token and args.key:
-            await device.authenticate(args.token, args.key)
+            try:
+                await device.authenticate(args.token, args.key)
+            except AuthenticationError as e:
+                _LOGGER.error("Authentication failed. Error: %s", e)
+                exit(1)
 
     if not isinstance(device, AC):
         _LOGGER.error("Device is not supported.")

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -11,7 +11,7 @@ from msmart.const import (DEVICE_INFO_MSG, DISCOVERY_MSG,
                           OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD,
                           DeviceType)
 from msmart.device import AirConditioner, Device
-from msmart.lan import Security
+from msmart.lan import AuthenticationError, Security
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -381,8 +381,11 @@ class Discover:
                 _LOGGER.error(e)
                 continue
 
-            if await dev.authenticate(token, key, silent=True):
+            try:
+                await dev.authenticate(token, key)
                 return True
+            except AuthenticationError:
+                continue
 
         return False
 


### PR DESCRIPTION
Throw on authentication failures so the callers can handle failures intelligently based on their needs.

This is a somewhat **breaking** change! Previous implementation merely logged the failure and returned a boolean to indicate success. User of the library should put authentication calls in a `try...except` and handle failures gracefully.



