### PR TITLE
Accept PropertiesResponses with invalid CRCs. Redo of #114

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -9,7 +9,7 @@ from typing import Callable, Collection, Mapping, Optional, Union
 
 import msmart.crc8 as crc8
 from msmart.const import DeviceType, FrameType
-from msmart.frame import Frame
+from msmart.frame import Frame, InvalidFrameException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -335,15 +335,11 @@ class Response():
         return self._payload
 
     @classmethod
-    def validate(cls, frame: memoryview, skip_crc: bool = False) -> None:
-        """Validate a response by checking the frame checksum and payload CRC."""
-
-        # Attempt to validate the frame
-        Frame.validate(frame)
-
-        # Exit early if not checking CRC
-        if skip_crc:
-            return
+    def validate(cls, frame: memoryview) -> None:
+        try:
+            Frame.validate(frame)
+        except InvalidFrameException as e:
+            raise InvalidResponseException(e) from e
 
         # Extract frame payload to validate CRC/checksum
         payload = frame[10:-1]
@@ -357,13 +353,11 @@ class Response():
                 f"Payload '{payload.hex()}' failed CRC and checksum. Received: 0x{payload[-1]:X}, Expected: 0x{payload_crc:X} or 0x{payload_checksum:X}.")
 
     @classmethod
-    def construct(cls, frame: bytes, skip_crc: bool = False) -> Response:
-        """Construct a response object from raw data."""
-
+    def construct(cls, frame: bytes) -> Union[StateResponse, CapabilitiesResponse, Response]:
         # Build a memoryview of the frame for zero-copy slicing
         with memoryview(frame) as frame_mv:
             # Ensure frame is valid before parsing
-            Response.validate(frame_mv, skip_crc)
+            Response.validate(frame_mv)
 
             # Parse frame depending on id
             response_id = frame_mv[10]

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -5,7 +5,6 @@ from typing import Any, List, Optional, Union, cast
 
 from msmart.base_device import Device
 from msmart.const import DeviceType
-from msmart.frame import InvalidFrameException
 from msmart.utils import MideaIntEnum
 
 from .command import (CapabilitiesResponse, GetCapabilitiesCommand,
@@ -67,8 +66,6 @@ class AirConditioner(Device):
 
         super().__init__(ip=ip, port=port, device_id=device_id,
                          device_type=DeviceType.AIR_CONDITIONER, **kwargs)
-
-        self._disable_properties_crc_check = False
 
         self._beep_on = False
         self._power_state = False
@@ -232,7 +229,7 @@ class AirConditioner(Device):
                           self.ip, self.port, response.payload.hex())
 
     async def _send_command_get_responses(self, command) -> List[Response]:
-        """Send a command and return all valid responses."""
+        """Send a command and yield an iterator of valid response."""
 
         responses = await super()._send_command(command)
 
@@ -244,32 +241,12 @@ class AirConditioner(Device):
         # Device is online if we received any response
         self._online = True
 
-        # Determine if CRCs will be checked
-        properties_command = isinstance(command,
-                                        (GetPropertiesCommand, SetPropertiesCommand))
-        skip_crc = self._disable_properties_crc_check and properties_command
-
         valid_responses = []
         for data in responses:
             try:
-                try:
-                    # Construct response from data
-                    response = Response.construct(data, skip_crc=skip_crc)
-                except InvalidResponseException as e:
-                    if not properties_command:
-                        _LOGGER.error(e)
-                        continue
-
-                    # Some devices return invalid CRCs on properties responses
-                    # Detect and disable CRC checks on these responses
-                    _LOGGER.info(
-                        "Disabling CRC check for properties commands.")
-                    self._disable_properties_crc_check = True
-
-                    # Construct the failing response again without CRC check
-                    response = Response.construct(data, skip_crc=True)
-
-            except InvalidFrameException as e:
+                # Construct response from data
+                response = Response.construct(data)
+            except InvalidResponseException as e:
                 _LOGGER.error(e)
                 continue
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Union, cast
 
 from msmart.base_device import Device
 from msmart.const import DeviceType
+from msmart.frame import InvalidFrameException
 from msmart.utils import MideaIntEnum
 
 from .command import (CapabilitiesResponse, GetCapabilitiesCommand,
@@ -229,7 +230,7 @@ class AirConditioner(Device):
                           self.ip, self.port, response.payload.hex())
 
     async def _send_command_get_responses(self, command) -> List[Response]:
-        """Send a command and yield an iterator of valid response."""
+        """Send a command and return all valid responses."""
 
         responses = await super()._send_command(command)
 
@@ -246,7 +247,7 @@ class AirConditioner(Device):
             try:
                 # Construct response from data
                 response = Response.construct(data)
-            except InvalidResponseException as e:
+            except (InvalidFrameException, InvalidResponseException) as e:
                 _LOGGER.error(e)
                 continue
 

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -6,8 +6,8 @@ from msmart.frame import Frame
 
 from .command import (CapabilitiesResponse, CapabilityId, Command,
                       GetPropertiesCommand, GetStateCommand,
-                      InvalidResponseException, PropertiesResponse, PropertyId,
-                      Response, SetPropertiesCommand, StateResponse)
+                      PropertiesResponse, PropertyId, Response,
+                      SetPropertiesCommand, StateResponse)
 
 
 class _TestResponseBase(unittest.TestCase):
@@ -656,33 +656,6 @@ class TestPropertiesResponse(_TestResponseBase):
 
         # Check state
         self.assertEqual(resp.swing_horizontal_angle, 50)
-
-    def test_properties_response_invalid_crc(self) -> None:
-        """Test we decode a properties response sent with an invalid CRC correctly."""
-        # https://github.com/mill1000/midea-ac-py/issues/101#issuecomment-1994824924
-        TEST_RESPONSE = bytes.fromhex(
-            "aa14ac00000000000303b10109000001003c000042")
-
-        # Assert that constructing with CRC checks results in an exception
-        with self.assertRaises(InvalidResponseException):
-            resp = Response.construct(TEST_RESPONSE, skip_crc=False)
-
-        # Create response without checking CRC and assert it's expected type
-        resp = Response.construct(TEST_RESPONSE, skip_crc=True)
-
-        self.assertIsNotNone(resp)
-        self.assertEqual(type(resp), PropertiesResponse)
-        resp = cast(PropertiesResponse, resp)
-
-        EXPECTED_RAW_PROPERTIES = {
-            PropertyId.SWING_UD_ANGLE: 0,
-        }
-        # Ensure raw decoded properties match
-        self.assertEqual(resp._properties, EXPECTED_RAW_PROPERTIES)
-
-        # Check state
-        self.assertEqual(resp.swing_vertical_angle, 0)
-        self.assertIsNone(resp.swing_horizontal_angle)
 
 
 if __name__ == "__main__":

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -1,8 +1,6 @@
 import unittest
-from unittest.mock import patch
 
-from .command import (GetPropertiesCommand, GetStateCommand,
-                      PropertiesResponse, PropertyId, Response, StateResponse)
+from .command import PropertiesResponse, Response, StateResponse
 from .device import AirConditioner as AC
 
 
@@ -210,69 +208,6 @@ class TestUpdateStateFromResponse(unittest.TestCase):
 
         # Assert other properties are untouched
         self.assertEqual(device.vertical_swing_angle, AC.SwingAngle.POS_5)
-
-
-class TestSendCommand(unittest.IsolatedAsyncioTestCase):
-
-    @patch("msmart.device.Device._send_command")
-    async def test_response_ignore_bad_crc(self, mock_send_command) -> None:
-        """Test that bad CRCs are ignored when in response to properties commands."""
-        TEST_RESPONSE_BAD_CRC = bytes.fromhex(
-            "aa14ac00000000000303b10109000001003c000042")
-        TEST_RESPONSE_BAD_CHECKSUM = bytes.fromhex(
-            "aa14ac00000000000303b10109000001003c0000FF")
-
-        # Set return value of mocked method
-        mock_send_command.return_value = [TEST_RESPONSE_BAD_CRC]
-
-        # Create a dummy device
-        device = AC(0, 0, 0)
-
-        # Assert we start not ignoring CRCs
-        self.assertEqual(device._disable_properties_crc_check, False)
-
-        # Send a properties command
-        command = GetPropertiesCommand([PropertyId.SWING_UD_ANGLE])
-        responses = await device._send_command_get_responses(command)
-
-        # Assert that responses are received
-        self.assertTrue(responses)
-
-        # Assert we start are now ignoring CRCs
-        self.assertEqual(device._disable_properties_crc_check, True)
-
-        # Check that we still check CRCs on non-properties commands
-        with self.assertLogs("msmart") as log:
-            command = GetStateCommand()
-            responses = await device._send_command_get_responses(command)
-
-            # Assert that no responses received
-            self.assertFalse(responses)
-
-        # Assert that an error was generated
-        self.assertRegex(log.output[0], "^ERROR:.*Payload.*failed CRC")
-
-        # Change mocked return to an invalid frame
-        mock_send_command.return_value = [TEST_RESPONSE_BAD_CHECKSUM]
-
-        # Assert that checksums are always checked regardless of command
-        with self.assertLogs("msmart") as log:
-            command = GetStateCommand()
-            responses = await device._send_command_get_responses(command)
-
-            # Assert that no responses received
-            self.assertFalse(responses)
-
-            # Send a properties command
-            command = GetPropertiesCommand([PropertyId.SWING_UD_ANGLE])
-            responses = await device._send_command_get_responses(command)
-
-            # Assert that no responses received
-            self.assertFalse(responses)
-
-        # Assert that an error was generated
-        self.assertRegex(log.output[0], "^ERROR:.*Frame.*failed checksum")
-        self.assertRegex(log.output[1], "^ERROR:.*Frame.*failed checksum")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Original attempt in #114 had some shortcomings due to the adhoc nature of responses. It was possible for a PropertiesResponse to appear to be received in response from another command which caused the CRC to fail.

This approach is a little more of a hammer. It simply ignores the CRC on all PropertiesResponse.