### PR TITLE
Ignore "capability" responses with unexpected frame type.

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -356,10 +356,12 @@ class Response():
             Frame.validate(frame_mv)
 
             # Fetch the appropriate response class from the ID
+            frame_type = frame_mv[9]
             response_id = frame_mv[10]
             if response_id == ResponseId.STATE:
                 response_class = StateResponse
-            elif response_id == ResponseId.CAPABILITIES:
+            elif response_id == ResponseId.CAPABILITIES and frame_type == FrameType.QUERY:
+                # Some devices have unsolicited "capabilities" responses with a frame type of 0x5
                 response_class = CapabilitiesResponse
             elif response_id in [ResponseId.PROPERTIES, ResponseId.PROPERTIES_ACK]:
                 response_class = PropertiesResponse

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -662,6 +662,17 @@ class TestPropertiesResponse(_TestResponseBase):
         self.assertEqual(resp.get_property(PropertyId.SWING_LR_ANGLE), 50)
         self.assertEqual(resp.get_property(PropertyId.SWING_UD_ANGLE), 0)
 
+    def test_properties_notify(self) -> None:
+        """Test ignore property notifications."""
+        # https://github.com/mill1000/midea-msmart/issues/122
+        TEST_RESPONSE = bytes.fromhex(
+            "aa1aac00000000000205b50310060101090001010a000101dcbcb4")
+
+        resp = self._test_build_response(TEST_RESPONSE)
+
+        # Assert response is generic
+        self.assertEqual(type(resp), Response)
+
 
 class TestResponseConstruct(_TestResponseBase):
     """Test construction of responses from raw data."""


### PR DESCRIPTION
Close #122 

Add test case to ensure 0xB5 responses with different frame types are ignored.