### PR TITLE
Fix unsupported property warnings for Buzzer ID in logs

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -792,6 +792,7 @@ class PropertiesResponse(Response):
         # keys for each. e.g. capabilities
         parsers = {
             PropertyId.ANION: lambda v: v[0],
+            PropertyId.BUZZER: lambda v: None,  # Don't bother parsing buzzer state
             PropertyId.FRESH_AIR: lambda v: (v[0], v[1], v[2]),
             PropertyId.INDOOR_HUMIDITY: lambda v: v[0],
             PropertyId.RATE_SELECT: lambda v: v[0],
@@ -834,7 +835,8 @@ class PropertiesResponse(Response):
             # Apply parser if it exists
             if parser is not None:
                 # Parse the property
-                self._properties.update({property: parser(props[4:])})
+                if (value := parser(props[4:])) is not None:
+                    self._properties.update({property: value})
 
             else:
                 _LOGGER.warning(

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -485,7 +485,7 @@ class CapabilitiesResponse(Response):
                 capability_id = CapabilityId(raw_id)
             except ValueError:
                 _LOGGER.warning(
-                    "Unknown capability. ID: 0x%4X, Size: %d.", raw_id, size)
+                    "Unknown capability. ID: 0x%04X, Size: %d.", raw_id, size)
                 # Advanced to next capability
                 caps = caps[3+size:]
                 continue
@@ -823,7 +823,7 @@ class PropertiesResponse(Response):
                 property = PropertyId(raw_id)
             except ValueError:
                 _LOGGER.warning(
-                    "Unknown property. ID: 0x%4X, Size: %d.", raw_id, size)
+                    "Unknown property. ID: 0x%04X, Size: %d.", raw_id, size)
                 # Advanced to next property
                 props = props[4+size:]
                 continue


### PR DESCRIPTION
When testing Anion supports, some other warnings were generated in the logs about an unsupported property

```
2024-05-07 00:28:46.302 WARNING (MainThread) [msmart.device.AC.command] Unsupported property. ID: 0x001A, Size: 1.
``` 

This is due to #120, in which the Buzzer property was inserted into every Properties command. However, a parser was never defined for the response.

We don't really care about the response, so define a parser that returns None and don't store it.