### PR TITLE
Revert broken Anion implementation

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -553,10 +553,6 @@ class CapabilitiesResponse(Response):
     def additional_capabilities(self) -> bool:
         return self._additional_capabilities
 
-    @property
-    def anion(self) -> bool:
-        return self._capabilities.get("anion", False)
-
     # TODO rethink these properties for fan speed, operation mode and swing mode
     # Surely there's a better way than define props for each possible cap
     @property

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -57,7 +57,6 @@ class AirConditioner(Device):
 
     # Create a dict to map properties to attribute names
     _PROPERTY_MAP = {
-        PropertyId.ANION: "_anion",
         PropertyId.SWING_LR_ANGLE: "_horizontal_swing_angle",
         PropertyId.SWING_UD_ANGLE: "_vertical_swing_angle"
     }
@@ -109,7 +108,6 @@ class AirConditioner(Device):
 
         self._horizontal_swing_angle = AirConditioner.SwingAngle.OFF
         self._vertical_swing_angle = AirConditioner.SwingAngle.OFF
-        self._anion = False
 
     def _update_state(self, res: Union[StateResponse, PropertiesResponse]) -> None:
         if isinstance(res, StateResponse):
@@ -162,9 +160,6 @@ class AirConditioner(Device):
                 self._vertical_swing_angle = cast(
                     AirConditioner.SwingAngle,
                     AirConditioner.SwingAngle.get_from_value(angle))
-
-            if anion := res.get_property(PropertyId.ANION):
-                self._anion = anion
 
     def _update_capabilities(self, res: CapabilitiesResponse) -> None:
         # Build list of supported operation modes
@@ -224,9 +219,6 @@ class AirConditioner(Device):
 
         if res.swing_horizontal_angle:
             self._supported_properties.add(PropertyId.SWING_LR_ANGLE)
-
-        if res.anion:
-            self._supported_properties.add(PropertyId.ANION)
 
     def _process_state_response(self, response: Response) -> None:
         """Update the local state from a device state response."""
@@ -509,19 +501,6 @@ class AirConditioner(Device):
     def vertical_swing_angle(self, angle: SwingAngle) -> None:
         self._vertical_swing_angle = angle
         self._updated_properties.add(PropertyId.SWING_UD_ANGLE)
-
-    @property
-    def supports_anion(self) -> bool:
-        return PropertyId.ANION in self._supported_properties
-
-    @property
-    def anion(self) -> bool:
-        return self._anion
-
-    @anion.setter
-    def anion(self, enabled: bool) -> None:
-        self._anion = enabled
-        self._updated_properties.add(PropertyId.ANION)
 
     @property
     def supports_eco_mode(self) -> Optional[bool]:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -633,7 +633,6 @@ class TestPropertiesResponse(_TestResponseBase):
         self.assertEqual(resp._properties, EXPECTED_RAW_PROPERTIES)
 
         # Check state
-        self.assertIsNone(resp.get_property(PropertyId.ANION))
         self.assertEqual(resp.get_property(PropertyId.INDOOR_HUMIDITY), 43)
         self.assertEqual(resp.get_property(PropertyId.SWING_LR_ANGLE), 0)
         self.assertEqual(resp.get_property(PropertyId.SWING_UD_ANGLE), 0)
@@ -658,7 +657,6 @@ class TestPropertiesResponse(_TestResponseBase):
         self.assertEqual(resp._properties, EXPECTED_RAW_PROPERTIES)
 
         # Check state
-        self.assertIsNone(resp.get_property(PropertyId.ANION))
         self.assertEqual(resp.get_property(PropertyId.SWING_LR_ANGLE), 50)
         self.assertEqual(resp.get_property(PropertyId.SWING_UD_ANGLE), 0)
 

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -152,7 +152,6 @@ class TestUpdateStateFromResponse(unittest.TestCase):
 
         # Assert state is expected
         # TODO Test cases doesn't test values that differ from defaults
-        self.assertEqual(device.anion, False)
         self.assertEqual(device.horizontal_swing_angle, AC.SwingAngle.OFF)
         self.assertEqual(device.vertical_swing_angle, AC.SwingAngle.OFF)
 
@@ -173,7 +172,6 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         device._process_state_response(resp)
 
         # Assert state is expected
-        self.assertEqual(device.anion, False)
         self.assertEqual(device.horizontal_swing_angle, AC.SwingAngle.POS_3)
         self.assertEqual(device.vertical_swing_angle, AC.SwingAngle.OFF)
 
@@ -187,7 +185,6 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         device = AC(0, 0, 0)
 
         # Set some properties
-        device.anion = True
         device.horizontal_swing_angle = AC.SwingAngle.POS_5
         device.vertical_swing_angle = AC.SwingAngle.POS_5
 
@@ -203,7 +200,6 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         self.assertEqual(device.horizontal_swing_angle, AC.SwingAngle.POS_3)
 
         # Assert other properties are untouched
-        self.assertEqual(device.anion, True)
         self.assertEqual(device.vertical_swing_angle, AC.SwingAngle.POS_5)
 
 


### PR DESCRIPTION
The current Anion implementation is broken (#124, https://github.com/mill1000/midea-ac-py/issues/131, https://github.com/mill1000/midea-ac-py/issues/128).

While #126 is being worked on and debugged, this reverts the current implementation.