### PR TITLE
Add control capability to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,20 @@ pip install msmart-ng
 
 ## Usage
 ### CLI
-A simple command line interface is provided to discover and query devices. 
+A simple command line interface is provided to discover, query and contorl devices. 
 
 ```shell
 $ msmart-ng --help
-usage: msmart-ng [-h] [-v] {discover,query} ...
+usage: msmart-ng [-h] [-v] {discover,query,control,download} ...
 
 Command line utility for msmart-ng.
 
 options:
-  -h, --help        show this help message and exit
-  -v, --version     show program's version number and exit
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
 
 Command:
-  {discover,query}
+  {discover,query,control,download}
 ```
 
 Each subcommand has additional help available. e.g. `msmart-ng discover --help`
@@ -124,6 +124,21 @@ $ msmart-ng query <HOST>
 ```
 
 Device capabilities can be queried with the `--capabilities` argument.
+
+#### Control
+Control device state with the `msmart-ng control` subcommand. The command takes a space seperated list of key-value pairs of settings to control.
+
+Enumerated settings like `operational_mode`, `fan_speed`, and `swing_mode` can accept integer or string values. e.g. `operational_mode=cool`, `fan_speed=100` or `swing_mode=both`.
+
+Number settings like `target_temperature` can accept floating point or integer values. e.g. `target_temperature=20.5`.
+
+Boolean settings like `display_on` and `beep` can accept integer or string values. e.g. `display_on=True` or `beep=0`.
+
+**Note:** Version 3 devices need to specify either the `--auto` argument or the `--token`, `--key` and `--id` arguments to make a connection.
+
+```shell
+$ msmart-ng control <HOST> operational_mode=cool target_temperature=20.5 fan_speed=100 display_on=True beep=0
+```
 
 ### Home Assistant
 Use [this fork](https://github.com/mill1000/midea-ac-py) of midea-ac-py to control devices from Home Assistant.

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -134,12 +134,12 @@ async def _control(args) -> None:
         prop = getattr(AC, name, None)
         if prop is None or not isinstance(prop, property):
             _LOGGER.error("'%s' is not a valid device property.", name)
-            raise ValueError
+            exit(1)
 
         # Check if property has a setter, with special handling for the display
         if name != KEY_DISPLAY_ON and prop.fset is None:
             _LOGGER.error("'%s' property is not writable.", name)
-            raise ValueError
+            exit(1)
 
         # Get the default value of the property and its type
         attr_value = getattr(AC("0.0.0.0", 0, 0), name)

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -184,6 +184,14 @@ async def _control(args) -> None:
     _LOGGER.info("Querying device state.")
     await device.refresh()
 
+    if not device.online:
+            _LOGGER.error("Device is not online.")
+            exit(1)
+
+    if args.capabilities:
+        _LOGGER.info("Querying device capabilities.")
+        await device.get_capabilities()
+
     # Handle display which is unique
     if (display := new_properties.pop(KEY_DISPLAY_ON, None)) is not None:
         if display != device.display_on:
@@ -342,6 +350,9 @@ def main() -> NoReturn:
                                            parents=[common_parser])
     control_parser.add_argument("host",
                                 help="Hostname or IP address of device.")
+    control_parser.add_argument("--capabilities",
+                              help="Query device capabilities before sending commands.",
+                              action="store_true")
     control_parser.add_argument("--auto",
                                 help="Automatically authenticate V3 devices.",
                                 action="store_true")

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -185,8 +185,8 @@ async def _control(args) -> None:
     await device.refresh()
 
     if not device.online:
-            _LOGGER.error("Device is not online.")
-            exit(1)
+        _LOGGER.error("Device is not online.")
+        exit(1)
 
     if args.capabilities:
         _LOGGER.info("Querying device capabilities.")
@@ -351,8 +351,8 @@ def main() -> NoReturn:
     control_parser.add_argument("host",
                                 help="Hostname or IP address of device.")
     control_parser.add_argument("--capabilities",
-                              help="Query device capabilities before sending commands.",
-                              action="store_true")
+                                help="Query device capabilities before sending commands.",
+                                action="store_true")
     control_parser.add_argument("--auto",
                                 help="Automatically authenticate V3 devices.",
                                 action="store_true")


### PR DESCRIPTION
Add new `control` command to the CLI which enables setting device properties.

Basic syntax is as follows:
```
msmart-ng control DEVICE_IP setting1=value1 setting2=value2
```

The CLI will attempt to convert the incoming values to the correct types. 

- Enum types can use the number and/or the name. 
- Booleans can be written as true/false or True/False


Example
```
msmart-ng control DEVICE_IP power_state=True fan_speed=20 target_temperature=25 operational_mode=heat display_on=True
```

Close #96 