### PR TITLE
Disable pruning of untagged Docker images

### DIFF
--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           container: ${{ env.CONTAINER_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Prune all untagged
-          prune-untagged: true
           # Keep PRs, releases, latest and edge
           keep-tags-regexes: |
             ^pr-


### PR DESCRIPTION
Disable pruning of untagged images to prevent breaking multi-arch images until a better solution is found.

https://github.com/snok/container-retention-policy/issues/63
https://github.com/vlaurin/action-ghcr-prune/issues/76