### PR TITLE
Fix tagged docker images reporting different version than tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,4 @@ __pycache__
 dist/
 build
 *.egg-info
-.*
-!.git
-Dockerfile
+*.vscode/


### PR DESCRIPTION
Currently the Docker images don't have msmart-ng versions that match their tag.
```
docker run --network=host ghcr.io/mill1000/msmart-ng:2024.7.0 -v
msmart version: 2024.7.1.dev0+gab34eb4.d20240710
```

Update dockerignore to ensure `git status` is clean when building Docker images, to ensure the built version matches the tag.