### PR TITLE
Add a MAX fan speed when custom speeds are supported

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -23,6 +23,7 @@ class AirConditioner(Device):
 
     class FanSpeed(MideaIntEnum):
         AUTO = 102
+        MAX = 100
         HIGH = 80
         MEDIUM = 60
         LOW = 40
@@ -227,6 +228,9 @@ class AirConditioner(Device):
             fan_speeds.append(AirConditioner.FanSpeed.HIGH)
         if res.fan_auto:
             fan_speeds.append(AirConditioner.FanSpeed.AUTO)
+        if res.fan_custom:
+            # Include additional MAX speed if custom speeds are supported
+            fan_speeds.append(AirConditioner.FanSpeed.MAX)
 
         self._supported_fan_speeds = fan_speeds
         self._supports_custom_fan_speed = res.fan_custom


### PR DESCRIPTION
Some users have raised issues that "high" is not 100. The "high" fan speed was reduced to 80 in #104.

https://github.com/mill1000/midea-ac-py/issues/143
https://github.com/mill1000/midea-ac-py/issues/96

As a comprise, this PR adds a new fan speed "Max" but it's only made available when custom speeds are supported.