### PR TITLE
Default humidity support to False

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -103,8 +103,8 @@ class AirConditioner(Device):
         self._supports_display_control = True
         self._supports_filter_reminder = True
         self._supports_purifier = True
-        self._supports_humidity = True
-        self._supports_target_humidity = True
+        self._supports_humidity = False
+        self._supports_target_humidity = False
         self._min_target_temperature = 16
         self._max_target_temperature = 30
 


### PR DESCRIPTION
Some users have devices that don't respond to humidity messages causing the device to appear offline when refresh() is called.

https://github.com/mill1000/midea-ac-py/issues/188