### PR TITLE
Add peer information to more logs

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -45,7 +45,7 @@ class Device():
             response_time = round(time.time() - start, 2)
 
         if responses is None:
-            _LOGGER.warning("No response from %s:%d in %f seconds. ",
+            _LOGGER.warning("No response from %s:%d in %f seconds.",
                             self.ip, self.port, response_time)
             return None
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -321,7 +321,8 @@ class AirConditioner(Device):
         response = cast(CapabilitiesResponse, response)
 
         if response is None:
-            _LOGGER.error("Failed to query device capabilities.")
+            _LOGGER.error(
+                "Failed to query capabilities from %s:%d.", self.ip, self.port)
             return
 
         # Send 2nd capabilities request if needed
@@ -336,7 +337,7 @@ class AirConditioner(Device):
                 response.merge(additional_response)
             else:
                 _LOGGER.warning(
-                    "Failed to query additional device capabilities.")
+                    "Failed to query additional capabilities from %s:%d.", self.ip, self.port)
 
         # Update device capabilities
         self._update_capabilities(response)


### PR DESCRIPTION
Add additional peer information to certain log statements.  This should ease debugging when multiple devices are present.