### PR TITLE
Fix inability to turn off breeze modes

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -80,7 +80,7 @@ class AirConditioner(Device):
         PropertyId.BREEZE_AWAY: lambda s: 2 if s._breeze_away else 1,
         PropertyId.BREEZE_CONTROL: lambda s: (4 if s._breezeless else
                                               (3 if s._breeze_mild else
-                                               (2 if s._breeze_away else 0))),
+                                               (2 if s._breeze_away else 1))),
         PropertyId.BREEZELESS: lambda s: s._breezeless,
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 
 from .command import (EnergyUsageResponse, HumidityResponse,
@@ -175,8 +176,13 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         device.horizontal_swing_angle = AC.SwingAngle.OFF
         device.vertical_swing_angle = AC.SwingAngle.OFF
 
-        resp = Response.construct(TEST_RESPONSE)
-        self.assertIsNotNone(resp)
+        # Device did not support SWING_UD_ANGLE, check that an error was reported
+        with self.assertLogs("msmart", logging.WARNING) as log:
+            resp = Response.construct(TEST_RESPONSE)
+            self.assertIsNotNone(resp)
+
+            self.assertRegex(
+                log.output[0], "Property .*SWING_UD_ANGLE.* failed, Result: 0x11.")
 
         # Assert response is a state response
         self.assertEqual(type(resp), PropertiesResponse)


### PR DESCRIPTION
It appears devices want a value of 0x01 to disable breeze modes, even though they return a value of 0 to indicate it's off.

Add checks for execution errors in properties responses.

Add/modify test cases for these execution errors

Close #161 

