### PR TITLE
Use enum for "breeze" mode

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -659,7 +659,7 @@ class AirConditioner(Device):
 
     @property
     def breeze_mild(self) -> Optional[bool]:
-        self._breeze_mode = AirConditioner.BreezeMode.BREEZE_MILD
+        return self._breeze_mode == AirConditioner.BreezeMode.BREEZE_MILD
 
     @breeze_mild.setter
     def breeze_mild(self, enable: bool) -> None:
@@ -675,7 +675,7 @@ class AirConditioner(Device):
 
     @property
     def breezeless(self) -> Optional[bool]:
-        self._breeze_mode = AirConditioner.BreezeMode.BREEZELESS
+        return self._breeze_mode == AirConditioner.BreezeMode.BREEZELESS
 
     @breezeless.setter
     def breezeless(self, enable: bool) -> None:

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -222,17 +222,18 @@ class AirConditioner(Device):
                     AirConditioner.RateSelect,
                     AirConditioner.RateSelect.get_from_value(rate))
 
-            if (value := res.get_property(PropertyId.BREEZE_AWAY)) is not None:
-                self._breeze_mode = (AirConditioner.BreezeMode.BREEZE_AWAY if (value == 2)
-                                     else AirConditioner.BreezeMode.OFF)
-
+            # Breeze control supersedes breeze away and breezeless
             if (value := res.get_property(PropertyId.BREEZE_CONTROL)) is not None:
                 self._breeze_mode = (AirConditioner.BreezeMode(value) if value in AirConditioner.BreezeMode
                                      else AirConditioner.BreezeMode.OFF)
+            else:
+                if (value := res.get_property(PropertyId.BREEZE_AWAY)) is not None:
+                    self._breeze_mode = (AirConditioner.BreezeMode.BREEZE_AWAY if (value == 2)
+                                         else AirConditioner.BreezeMode.OFF)
 
-            if (value := res.get_property(PropertyId.BREEZELESS)) is not None:
-                self._breeze_mode = (AirConditioner.BreezeMode.BREEZELESS if bool(value)
-                                     else AirConditioner.BreezeMode.OFF)
+                if (value := res.get_property(PropertyId.BREEZELESS)) is not None:
+                    self._breeze_mode = (AirConditioner.BreezeMode.BREEZELESS if bool(value)
+                                         else AirConditioner.BreezeMode.OFF)
 
         elif isinstance(res, EnergyUsageResponse):
             self._total_energy_usage = res.total_energy

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -224,7 +224,7 @@ class AirConditioner(Device):
 
             # Breeze control supersedes breeze away and breezeless
             if (value := res.get_property(PropertyId.BREEZE_CONTROL)) is not None:
-                self._breeze_mode = (AirConditioner.BreezeMode(value) if value in AirConditioner.BreezeMode
+                self._breeze_mode = (AirConditioner.BreezeMode(value) if value in AirConditioner.BreezeMode.list()
                                      else AirConditioner.BreezeMode.OFF)
             else:
                 if (value := res.get_property(PropertyId.BREEZE_AWAY)) is not None:


### PR DESCRIPTION
Tidy up "breeze" mode implementation using an enum to make the interaction between breeze away, breeze mild and breezeless more seamless