### PR TITLE
Refactor property decode/encode

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -93,7 +93,7 @@ class PropertyId(IntEnum):
         elif self == PropertyId.BUZZER:
             return None  # Don't decode buzzer
         elif self == PropertyId.IECO:
-            return data[1]  # data[0] - ieco_number, data[1] - ieco_switch
+            return bool(data[1])  # data[0] - ieco_number, data[1] - ieco_switch
         else:
             return data[0]
 

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -85,6 +85,27 @@ class PropertyId(IntEnum):
     IECO = 0x00E3
     ANION = 0x021E
 
+    def decode(self, data: bytes) -> Any:
+        if self in [PropertyId.BREEZELESS, PropertyId.SELF_CLEAN]:
+            return bool(data[0])
+        elif self == PropertyId.BREEZE_AWAY:
+            return data[0] == 2
+        elif self == PropertyId.BUZZER:
+            return None  # Don't decode buzzer
+        elif self == PropertyId.IECO:
+            return data[1]  # data[0] - ieco_number, data[1] - ieco_switch
+        else:
+            return data[0]
+
+    def encode(self, *args, **kwargs) -> bytes:
+        if self == PropertyId.BREEZE_AWAY:
+            return bytes([2 if args[0] else 1])
+        elif self == PropertyId.IECO:
+            # ieco_frame, ieco_number, ieco_switch, ...
+            return bytes([0, 1, args[0]]) + bytes(10)
+        else:
+            return bytes(args[0:1])
+
 
 class TemperatureType(IntEnum):
     UNKNOWN = 0
@@ -344,7 +365,7 @@ class GetPropertiesCommand(Command):
 class SetPropertiesCommand(Command):
     """Command to set specific properties of the device."""
 
-    def __init__(self, props: Mapping[PropertyId, Union[bytes, int]]) -> None:
+    def __init__(self, props: Mapping[PropertyId, Union[int, bool]]) -> None:
         super().__init__(frame_type=FrameType.CONTROL)
 
         self._properties = props
@@ -358,8 +379,8 @@ class SetPropertiesCommand(Command):
         for prop, value in self._properties.items():
             payload += struct.pack("<H", prop)
 
-            if isinstance(value, int):
-                value = bytes([value])
+            # Encode property value to bytes
+            value = prop.encode(value)
 
             payload += bytes([len(value)])
             payload += value
@@ -900,26 +921,6 @@ class PropertiesResponse(Response):
         # Clear existing properties
         self._properties.clear()
 
-        # Define parsing functions for supported properties
-        # TODO when a properties has multiple field .e.g fresh air
-        # should they be stored all under the fresh_air key or create different
-        # keys for each. e.g. capabilities
-        parsers = {
-            PropertyId.ANION: lambda v: v[0],
-            PropertyId.BREEZE_AWAY: lambda v: v[0],
-            PropertyId.BREEZE_CONTROL: lambda v: v[0],
-            PropertyId.BREEZELESS: lambda v: v[0],
-            PropertyId.BUZZER: lambda v: None,  # Don't bother parsing buzzer state
-            PropertyId.FRESH_AIR: lambda v: (v[0], v[1], v[2]),
-            # v[0] - ieco_number, v[1] - ieco_switch
-            PropertyId.IECO: lambda v: v[1],
-            PropertyId.INDOOR_HUMIDITY: lambda v: v[0],
-            PropertyId.RATE_SELECT: lambda v: v[0],
-            PropertyId.SELF_CLEAN: lambda v: v[0],
-            PropertyId.SWING_UD_ANGLE: lambda v: v[0],
-            PropertyId.SWING_LR_ANGLE: lambda v: v[0],
-        }
-
         count = payload[1]
         props = payload[2:]
 
@@ -948,17 +949,6 @@ class PropertiesResponse(Response):
                 props = props[4+size:]
                 continue
 
-            # Fetch parser for this property
-            parser = parsers.get(property, None)
-
-            # Check if parser exists
-            if parser is None:
-                _LOGGER.warning(
-                    "Unsupported property %r, Size: %d.", property, size)
-                # Advanced to next property
-                props = props[4+size:]
-                continue
-
             # Check execution result and log any errors
             error = props[2] & 0x10
             if error:
@@ -966,7 +956,7 @@ class PropertiesResponse(Response):
                     "Property %r failed, Result: 0x%02X.", property, props[2])
 
             # Parse the property
-            if (value := parser(props[4:])) is not None:
+            if (value := property.decode(props[4:])) is not None:
                 self._properties.update({property: value})
 
             # Advanced to next property

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -85,7 +85,9 @@ class PropertyId(IntEnum):
     IECO = 0x00E3
     ANION = 0x021E
 
+    @property
     def _supported(self) -> bool:
+        """Check if a property ID is supported/tested."""
         return self in [
             PropertyId.BREEZE_AWAY,
             PropertyId.BREEZE_CONTROL,
@@ -99,7 +101,8 @@ class PropertyId(IntEnum):
         ]
 
     def decode(self, data: bytes) -> Any:
-        if not self._supported():
+        """Decode raw property data into a convenient form."""
+        if not self._supported:
             raise NotImplementedError(f"{repr(self)} decode is not supported.")
 
         if self in [PropertyId.BREEZELESS, PropertyId.SELF_CLEAN]:
@@ -115,7 +118,8 @@ class PropertyId(IntEnum):
             return data[0]
 
     def encode(self, *args, **kwargs) -> bytes:
-        if not self._supported():
+        """Encode property into raw form."""
+        if not self._supported:
             raise NotImplementedError(f"{repr(self)} encode is not supported.")
 
         if self == PropertyId.BREEZE_AWAY:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -93,7 +93,8 @@ class PropertyId(IntEnum):
         elif self == PropertyId.BUZZER:
             return None  # Don't decode buzzer
         elif self == PropertyId.IECO:
-            return bool(data[1])  # data[0] - ieco_number, data[1] - ieco_switch
+            # data[0] - ieco_number, data[1] - ieco_switch
+            return bool(data[1])
         else:
             return data[0]
 

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -593,8 +593,7 @@ class TestSetPropertiesCommand(unittest.TestCase):
     def test_payload(self) -> None:
         """Test that we encode set properties payloads correctly."""
         # TODO this test is not based on a real world sample
-        PROPS = {PropertyId.SWING_UD_ANGLE: bytes(
-            [25]), PropertyId.SWING_LR_ANGLE: bytes([75])}
+        PROPS = {PropertyId.SWING_UD_ANGLE: 25, PropertyId.SWING_LR_ANGLE: 75}
 
         # Build command
         command = SetPropertiesCommand(PROPS)
@@ -610,11 +609,9 @@ class TestSetPropertiesCommand(unittest.TestCase):
         self.assertEqual(payload[2], PropertyId.SWING_UD_ANGLE & 0xFF)
         self.assertEqual(payload[3], PropertyId.SWING_UD_ANGLE >> 8 & 0xFF)
 
-        # Assert length is correct
-        self.assertEqual(payload[4], len(PROPS[PropertyId.SWING_UD_ANGLE]))
-
-        # Assert data is correct
-        self.assertEqual(payload[5], PROPS[PropertyId.SWING_UD_ANGLE][0])
+        # Assert length is correct and data is correct
+        self.assertEqual(payload[4], 1)
+        self.assertEqual(payload[5], PROPS[PropertyId.SWING_UD_ANGLE])
 
 
 class TestPropertiesResponse(_TestResponseBase):

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -613,6 +613,11 @@ class TestSetPropertiesCommand(unittest.TestCase):
         for (prop, value), expected_data in TEST_ENCODES.items():
             self.assertEqual(prop.encode(value), expected_data, msg=f"""Encode {
                              repr(prop)}, Value: {value}, Expected: {expected_data}""")
+        
+        # Validate "unsupported" properties raise exceptions
+        with self.assertRaisesRegex(NotImplementedError, ".* encode is not supported."):
+            PropertyId.ANION.encode(True)
+
 
     def test_payload(self) -> None:
         """Test that we encode set properties payloads correctly."""
@@ -668,6 +673,10 @@ class TestPropertiesResponse(_TestResponseBase):
         for (prop, data), expected_value in TEST_DECODES.items():
             self.assertEqual(prop.decode(data), expected_value, msg=f"""Decode {
                              repr(prop)}, Data: {data}, Expected: {expected_value}""")
+            
+        # Validate "unsupported" properties raise exceptions
+        with self.assertRaisesRegex(NotImplementedError, ".* decode is not supported."):
+            PropertyId.INDOOR_HUMIDITY.decode(bytes([1]))
 
     def test_properties_parsing(self) -> None:
         """Test we decode properties responses correctly."""

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -675,14 +675,18 @@ class TestPropertiesResponse(_TestResponseBase):
         TEST_RESPONSE = bytes.fromhex(
             "aa21ac00000000000303b10409000001000a00000100150000012b1e020000005fa3")
 
-        resp = self._test_build_response(TEST_RESPONSE)
+        with self.assertLogs("msmart", logging.WARNING) as log:
+            resp = self._test_build_response(TEST_RESPONSE)
+
+            # Check debug message is generated for ID 0x0040
+            self.assertRegex("\n".join(log.output),
+                             "Unsupported property .*INDOOR_HUMIDITY.*")
 
         # Assert response is a correct type
         self.assertEqual(type(resp), PropertiesResponse)
         resp = cast(PropertiesResponse, resp)
 
         EXPECTED_RAW_PROPERTIES = {
-            PropertyId.INDOOR_HUMIDITY: 43,
             PropertyId.SWING_LR_ANGLE: 0,
             PropertyId.SWING_UD_ANGLE: 0,
         }
@@ -690,7 +694,6 @@ class TestPropertiesResponse(_TestResponseBase):
         self.assertEqual(resp._properties, EXPECTED_RAW_PROPERTIES)
 
         # Check state
-        self.assertEqual(resp.get_property(PropertyId.INDOOR_HUMIDITY), 43)
         self.assertEqual(resp.get_property(PropertyId.SWING_LR_ANGLE), 0)
         self.assertEqual(resp.get_property(PropertyId.SWING_UD_ANGLE), 0)
 

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -613,11 +613,10 @@ class TestSetPropertiesCommand(unittest.TestCase):
         for (prop, value), expected_data in TEST_ENCODES.items():
             self.assertEqual(prop.encode(value), expected_data, msg=f"""Encode {
                              repr(prop)}, Value: {value}, Expected: {expected_data}""")
-        
+
         # Validate "unsupported" properties raise exceptions
         with self.assertRaisesRegex(NotImplementedError, ".* encode is not supported."):
             PropertyId.ANION.encode(True)
-
 
     def test_payload(self) -> None:
         """Test that we encode set properties payloads correctly."""
@@ -673,7 +672,7 @@ class TestPropertiesResponse(_TestResponseBase):
         for (prop, data), expected_value in TEST_DECODES.items():
             self.assertEqual(prop.decode(data), expected_value, msg=f"""Decode {
                              repr(prop)}, Data: {data}, Expected: {expected_value}""")
-            
+
         # Validate "unsupported" properties raise exceptions
         with self.assertRaisesRegex(NotImplementedError, ".* decode is not supported."):
             PropertyId.INDOOR_HUMIDITY.decode(bytes([1]))
@@ -684,10 +683,10 @@ class TestPropertiesResponse(_TestResponseBase):
         TEST_RESPONSE = bytes.fromhex(
             "aa21ac00000000000303b10409000001000a00000100150000012b1e020000005fa3")
 
+        # Response contains an unsupported property so check the log for warnings
         with self.assertLogs("msmart", logging.WARNING) as log:
             resp = self._test_build_response(TEST_RESPONSE)
 
-            # Check debug message is generated for ID 0x0040
             self.assertRegex("\n".join(log.output),
                              "Unsupported property .*INDOOR_HUMIDITY.*")
 

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -611,8 +611,8 @@ class TestSetPropertiesCommand(unittest.TestCase):
         }
 
         for (prop, value), expected_data in TEST_ENCODES.items():
-            self.assertEqual(prop.encode(value), expected_data, msg=f"Encode {
-                             repr(prop)}, Value: {value}, Expected: {expected_data}")
+            self.assertEqual(prop.encode(value), expected_data, msg=f"""Encode {
+                             repr(prop)}, Value: {value}, Expected: {expected_data}""")
 
     def test_payload(self) -> None:
         """Test that we encode set properties payloads correctly."""
@@ -666,8 +666,8 @@ class TestPropertiesResponse(_TestResponseBase):
         }
 
         for (prop, data), expected_value in TEST_DECODES.items():
-            self.assertEqual(prop.decode(data), expected_value, msg=f"Decode {
-                             repr(prop)}, Data: {data}, Expected: {expected_value}")
+            self.assertEqual(prop.decode(data), expected_value, msg=f"""Decode {
+                             repr(prop)}, Data: {data}, Expected: {expected_value}""")
 
     def test_properties_parsing(self) -> None:
         """Test we decode properties responses correctly."""

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -151,10 +151,15 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         device.horizontal_swing_angle = AC.SwingAngle.POS_5
         device.vertical_swing_angle = AC.SwingAngle.POS_5
 
-        resp = Response.construct(TEST_RESPONSE)
-        self.assertIsNotNone(resp)
+        with self.assertLogs("msmart", logging.WARNING) as log:
+            resp = Response.construct(TEST_RESPONSE)
+
+            # Check debug message is generated for ID 0x0040
+            self.assertRegex("\n".join(log.output),
+                             "Unsupported property .*INDOOR_HUMIDITY.*")
 
         # Assert response is a state response
+        self.assertIsNotNone(resp)
         self.assertEqual(type(resp), PropertiesResponse)
 
         # Process the response

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -151,10 +151,10 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         device.horizontal_swing_angle = AC.SwingAngle.POS_5
         device.vertical_swing_angle = AC.SwingAngle.POS_5
 
+        # Response contains an unsupported property so check the log for warnings
         with self.assertLogs("msmart", logging.WARNING) as log:
             resp = Response.construct(TEST_RESPONSE)
 
-            # Check debug message is generated for ID 0x0040
             self.assertRegex("\n".join(log.output),
                              "Unsupported property .*INDOOR_HUMIDITY.*")
 


### PR DESCRIPTION
- Relocate property encoding from device.py to command.py
- Replace property parsers with decode() method
- Add testcases to verify property encoding/decoding