### PR TITLE
Add alternate energy/power response parsing

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -145,6 +145,7 @@ class AirConditioner(Device):
         self._total_energy_usage = None
         self._current_energy_usage = None
         self._real_time_power_usage = None
+        self._use_binary_energy = False
 
         # Default to assuming device can't handle any properties
         self._supported_properties = set()
@@ -242,9 +243,9 @@ class AirConditioner(Device):
                 self._ieco_mode = value
 
         elif isinstance(res, EnergyUsageResponse):
-            self._total_energy_usage = res.total_energy
-            self._current_energy_usage = res.current_energy
-            self._real_time_power_usage = res.real_time_power
+            self._total_energy_usage = res.total_energy_binary if self._use_binary_energy else res.total_energy
+            self._current_energy_usage = res.current_energy_binary if self._use_binary_energy else res.current_energy
+            self._real_time_power_usage = res.real_time_power_binary if self._use_binary_energy else res.real_time_power
 
         elif isinstance(res, HumidityResponse):
             self._indoor_humidity = res.humidity
@@ -826,6 +827,14 @@ class AirConditioner(Device):
     @property
     def filter_alert(self) -> Optional[bool]:
         return self._filter_alert
+
+    @property
+    def use_alternate_energy_format(self) -> bool:
+        return self._use_binary_energy
+
+    @use_alternate_energy_format.setter
+    def use_alternate_energy_format(self, enable: bool) -> None:
+        self._use_binary_energy = enable
 
     @property
     def enable_energy_usage_requests(self) -> bool:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -841,6 +841,29 @@ class TestGroupDataResponse(_TestResponseBase):
             self.assertEqual(resp.current_energy, current)
             self.assertEqual(resp.real_time_power, real_time)
 
+    def test_binary_energy_usage(self) -> None:
+        """Test we decode binary energy usage responses correctly."""
+        TEST_RESPONSES = {
+            # https://github.com/mill1000/midea-ac-py/issues/204#issuecomment-2314705021
+            (150.4, .6, 279.5): bytes.fromhex("aa22ac00000000000803c1210144000005e00000000000000006000aeb000000487a5e"),
+
+            # https://github.com/mill1000/midea-msmart/pull/116#issuecomment-2218753545
+            (None, None, None): bytes.fromhex("aa20ac00000000000303c1210144000000000000000000000000000000000843bc"),
+        }
+
+        for power, response in TEST_RESPONSES.items():
+            resp = self._test_build_response(response)
+
+            # Assert response is a correct type
+            self.assertEqual(type(resp), EnergyUsageResponse)
+            resp = cast(EnergyUsageResponse, resp)
+
+            total, current, real_time = power
+
+            self.assertEqual(resp.total_energy_binary, total)
+            self.assertEqual(resp.current_energy_binary, current)
+            self.assertEqual(resp.real_time_power_binary, real_time)
+
     def test_humidity(self) -> None:
         """Test we decode humidity responses correctly."""
         TEST_RESPONSES = {


### PR DESCRIPTION
Parse energy data as both BCD and binary.

Add an option to the device class to switch between the 2.

Close #154