### PR TITLE
Fixed calculation of temperature with decimals

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -923,8 +923,8 @@ class StateResponse(Response):
         def decode_temp(d: int) -> Optional[float]:
             return ((d - 50)/2 if d != 0xFF else None)
 
-        self.indoor_temperature = int(decode_temp(payload[11]))
-        self.outdoor_temperature = int(decode_temp(payload[12]))
+        self.indoor_temperature = decode_temp(payload[11])
+        self.outdoor_temperature = decode_temp(payload[12])
 
         # Decode alternate target temperature
         target_temperature_alt = payload[13] & 0x1F
@@ -939,10 +939,28 @@ class StateResponse(Response):
 
         # Decode additional temperature resolution
         if self.indoor_temperature:
-            self.indoor_temperature += (payload[15] & 0xF) / 10
+            indoor_decimals = (payload[15] & 0xF) / 10;
+
+            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5) 
+            # and the decimals are returned as remainder of whole number (ie 0.9)
+            # Result should be 28.9, but original approach calculated 29.4
+            indoor_temperature_remainder = self.indoor_temperature % 1;
+            if(indoor_decimals >= 0.5 and indoor_temperature_remainder == 0.5):
+                self.indoor_temperature = int(self.indoor_temperature)
+            
+            self.indoor_temperature += indoor_decimals;
 
         if self.outdoor_temperature:
-            self.outdoor_temperature += (payload[15] >> 4) / 10
+            outdoor_decimals = (payload[15] >> 4) / 10;
+
+            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5) 
+            # and the decimals are returned as remainder of whole number (ie 0.9)
+            # Result should be 28.9, but original approach calculated 29.4
+            outdoor_temperature_remainder = self.outdoor_temperature % 1;
+            if(outdoor_decimals >= 0.5 and outdoor_temperature_remainder == 0.5):
+                self.outdoor_temperature = int(self.outdoor_temperature)
+            
+            self.outdoor_temperature += outdoor_decimals
 
         # TODO Some payloads are shorter than expected. Unsure what, when or why
         # The lengths below were picked arbitrarily from user payload data

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -939,27 +939,27 @@ class StateResponse(Response):
 
         # Decode additional temperature resolution
         if self.indoor_temperature:
-            indoor_decimals = (payload[15] & 0xF) / 10;
+            indoor_decimals = (payload[15] & 0xF) / 10
 
-            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5) 
+            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5)
             # and the decimals are returned as remainder of whole number (ie 0.9)
             # Result should be 28.9, but original approach calculated 29.4
-            indoor_temperature_remainder = self.indoor_temperature % 1;
-            if(indoor_decimals >= 0.5 and indoor_temperature_remainder == 0.5):
+            indoor_temperature_remainder = self.indoor_temperature % 1
+            if indoor_decimals >= 0.5 and indoor_temperature_remainder == 0.5:
                 self.indoor_temperature = int(self.indoor_temperature)
-            
-            self.indoor_temperature += indoor_decimals;
+
+            self.indoor_temperature += indoor_decimals
 
         if self.outdoor_temperature:
-            outdoor_decimals = (payload[15] >> 4) / 10;
+            outdoor_decimals = (payload[15] >> 4) / 10
 
-            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5) 
+            # Handle situation when temperature is retured rounded to 0.5 (ie 28.5)
             # and the decimals are returned as remainder of whole number (ie 0.9)
             # Result should be 28.9, but original approach calculated 29.4
-            outdoor_temperature_remainder = self.outdoor_temperature % 1;
-            if(outdoor_decimals >= 0.5 and outdoor_temperature_remainder == 0.5):
+            outdoor_temperature_remainder = self.outdoor_temperature % 1
+            if outdoor_decimals >= 0.5 and outdoor_temperature_remainder == 0.5:
                 self.outdoor_temperature = int(self.outdoor_temperature)
-            
+
             self.outdoor_temperature += outdoor_decimals
 
         # TODO Some payloads are shorter than expected. Unsure what, when or why

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -923,8 +923,8 @@ class StateResponse(Response):
         def decode_temp(d: int) -> Optional[float]:
             return ((d - 50)/2 if d != 0xFF else None)
 
-        self.indoor_temperature = decode_temp(payload[11])
-        self.outdoor_temperature = decode_temp(payload[12])
+        self.indoor_temperature = int(decode_temp(payload[11]))
+        self.outdoor_temperature = int(decode_temp(payload[12]))
 
         # Decode alternate target temperature
         target_temperature_alt = payload[13] & 0x1F

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -131,12 +131,12 @@ class TestStateResponse(_TestResponseBase):
         # Messages with additional temperature precision bits
         TEST_MESSAGES = {
             # https://github.com/mill1000/midea-msmart/issues/89#issuecomment-1783316836
-            (24.0, 25.1, 10.0): bytes.fromhex(
+            (24.0, 24.6, 9.5): bytes.fromhex(
                 "aa23ac00000000000203c00188647f7f000000000063450c0056190000000000000497c3"),
             # https://github.com/mill1000/midea-msmart/issues/89#issuecomment-1782352164
-            (24.0, 27.0, 10.2): bytes.fromhex(
+            (24.0, 26.5, 9.7): bytes.fromhex(
                 "aa23ac00000000000203c00188647f7f000000000067450c00750000000000000001a3b0"),
-            (24.0, 25.0, 10.0): bytes.fromhex(
+            (24.0, 25.0, 9.5): bytes.fromhex(
                 "aa23ac00000000000203c00188647f7f000080000064450c00501d00000000000001508e"),
         }
 
@@ -162,12 +162,12 @@ class TestStateResponse(_TestResponseBase):
             # Corrected target values from user reported values
             (16.0, 23.2, 18.4): bytes.fromhex("c00181667f7f003c00000060560400420000000000000048"),
             (16.5, 23.4, 18.4): bytes.fromhex("c00191667f7f003c00000060560400440000000000000049"),
-            (17.0, 24.1, 18.3): bytes.fromhex("c00181667f7f003c0000006156050036000000000000004a"),
-            (17.5, 24.3, 18.2): bytes.fromhex("c00191667f7f003c0000006156050028000000000000004b"),
-            (18.0, 24.3, 18.2): bytes.fromhex("c00182667f7f003c0000006156060028000000000000004c"),
-            (18.5, 24.3, 18.2): bytes.fromhex("c00192667f7f003c0000006156060028000000000000004d"),
-            (19.0, 24.3, 18.2): bytes.fromhex("c00183667f7f003c0000006156070028000000000000004e"),
-            (19.5, 24.0, 19.0): bytes.fromhex("c00193667f7f003c00000061570700550000000000000050"),
+            (17.0, 23.6, 18.3): bytes.fromhex("c00181667f7f003c0000006156050036000000000000004a"),
+            (17.5, 23.8, 18.2): bytes.fromhex("c00191667f7f003c0000006156050028000000000000004b"),
+            (18.0, 23.8, 18.2): bytes.fromhex("c00182667f7f003c0000006156060028000000000000004c"),
+            (18.5, 23.8, 18.2): bytes.fromhex("c00192667f7f003c0000006156060028000000000000004d"),
+            (19.0, 23.8, 18.2): bytes.fromhex("c00183667f7f003c0000006156070028000000000000004e"),
+            (19.5, 23.5, 18.5): bytes.fromhex("c00193667f7f003c00000061570700550000000000000050"),
         }
 
         for targets, payload in TEST_RESPONSES.items():


### PR DESCRIPTION
The reported temperature was wrong - decimal part never went ove 0.4.
Im not sure if this is general issue for more devices, or its just me, but I managed to find the culprit in for my Midea AC.

The temperature in payload is rounded to 0.5, but the fraction part is set to full range 0.0-0.9.  When adding it up, it results in incorrect values: 25.5+0.9 = 26.4 instead of 25.9 and in fact it never reaches values 25.5 - 25.9
I need to round the intergral part of temperature to 0.0 to get the correct result.

payload from my AC:
`c001ae647f7f00000000006541120099000000000000000100000000a9`

