### PR TITLE
Use trusted publishing with PyPi and generate digital attestations

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,13 +27,13 @@ jobs:
   publish-package:
     needs: build-package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Mandatory for trusted publishing
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # repository-url: https://test.pypi.org/legacy/
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        # with:
+        #   repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/