### PR TITLE
Add support for additional cloud credentials based on region

### DIFF
--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -6,13 +6,16 @@ from typing import NoReturn
 
 from msmart import __version__
 from msmart.cloud import Cloud, CloudError
-from msmart.const import OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD
+from msmart.const import CLOUD_CREDENTIALS
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
 from msmart.lan import AuthenticationError
 from msmart.utils import MideaIntEnum
 
 _LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_CLOUD_ACCOUNT, DEFAULT_CLOUD_PASSWORD = CLOUD_CREDENTIALS["US"]
 
 
 async def _discover(args) -> None:
@@ -270,7 +273,7 @@ def _run(args) -> NoReturn:
         logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     # Validate common arguments
-    if args.china and (args.account == OPEN_MIDEA_APP_ACCOUNT or args.password == OPEN_MIDEA_APP_PASSWORD):
+    if args.china and (args.account == DEFAULT_CLOUD_ACCOUNT or args.password == DEFAULT_CLOUD_PASSWORD):
         _LOGGER.error(
             "Account (phone number) and password of 美的美居 is required to use --china option.")
         exit(1)
@@ -301,10 +304,10 @@ def main() -> NoReturn:
                                help="Enable debug logging.", action="store_true")
     common_parser.add_argument("--account",
                                help="MSmartHome or 美的美居 username for discovery and automatic authentication",
-                               default=OPEN_MIDEA_APP_ACCOUNT)
+                               default=DEFAULT_CLOUD_ACCOUNT)
     common_parser.add_argument("--password",
                                help="MSmartHome or 美的美居 password for discovery and automatic authentication.",
-                               default=OPEN_MIDEA_APP_PASSWORD)
+                               default=DEFAULT_CLOUD_PASSWORD)
     common_parser.add_argument("--china",
                                help="Use China server for discovery and automatic authentication.",
                                action="store_true")
@@ -404,9 +407,9 @@ def _legacy_main() -> NoReturn:
     parser.add_argument(
         "-d", "--debug", help="Enable debug logging.", action="store_true")
     parser.add_argument(
-        "-a", "--account", help="MSmartHome or 美的美居 account username.", default=OPEN_MIDEA_APP_ACCOUNT)
+        "-a", "--account", help="MSmartHome or 美的美居 account username.", default=DEFAULT_CLOUD_ACCOUNT)
     parser.add_argument(
-        "-p", "--password", help="MSmartHome or 美的美居 account password.", default=OPEN_MIDEA_APP_PASSWORD)
+        "-p", "--password", help="MSmartHome or 美的美居 account password.", default=DEFAULT_CLOUD_PASSWORD)
     parser.add_argument(
         "-i", "--ip", help="IP address of a device. Useful if broadcasts don't work, or to query a single device.")
     parser.add_argument(

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -6,7 +6,7 @@ from typing import NoReturn
 
 from msmart import __version__
 from msmart.cloud import Cloud, CloudError
-from msmart.const import CLOUD_CREDENTIALS
+from msmart.const import CLOUD_CREDENTIALS, DEFAULT_CLOUD_REGION
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
 from msmart.lan import AuthenticationError
@@ -15,7 +15,7 @@ from msmart.utils import MideaIntEnum
 _LOGGER = logging.getLogger(__name__)
 
 
-DEFAULT_CLOUD_ACCOUNT, DEFAULT_CLOUD_PASSWORD = CLOUD_CREDENTIALS["US"]
+DEFAULT_CLOUD_ACCOUNT, DEFAULT_CLOUD_PASSWORD = CLOUD_CREDENTIALS[DEFAULT_CLOUD_REGION]
 
 
 async def _discover(args) -> None:
@@ -219,7 +219,7 @@ async def _download(args) -> None:
 
     # Use discovery to to find device information
     _LOGGER.info("Discovering %s on local network.", args.host)
-    device = await Discover.discover_single(args.host, region = args.region, account=args.account, password=args.password, auto_connect=False)
+    device = await Discover.discover_single(args.host, region=args.region, account=args.account, password=args.password, auto_connect=False)
 
     if device is None:
         _LOGGER.error("Device not found.")
@@ -235,7 +235,7 @@ async def _download(args) -> None:
         exit(1)
 
     # Get cloud connection
-    cloud = Cloud(args.region, account = args.account, password = args.password)
+    cloud = Cloud(args.region, account=args.account, password=args.password)
     try:
         await cloud.login()
     except CloudError as e:
@@ -305,7 +305,7 @@ def main() -> NoReturn:
     common_parser.add_argument("--region",
                                help="Country/region for built-in cloud credential selection.",
                                choices=CLOUD_CREDENTIALS.keys(),
-                               default="US")
+                               default=DEFAULT_CLOUD_REGION)
     common_parser.add_argument("--account",
                                help="Manually specify a MSmart username for cloud authentication.",
                                default=None)

--- a/msmart/cloud.py
+++ b/msmart/cloud.py
@@ -13,7 +13,7 @@ import httpx
 from Crypto.Cipher import AES
 from Crypto.Util import Padding
 
-from msmart.const import DeviceType
+from msmart.const import DeviceType, CLOUD_CREDENTIALS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,14 +54,28 @@ class Cloud:
     # Default number of request retries
     RETRIES = 3
 
-    def __init__(self, account: str, password: str,
-                 use_china_server: bool = False) -> None:
+    def __init__(self,
+                 region: str = "US",
+                 *,
+                 account: Optional[str] = None,
+                 password: Optional[str] = None,
+                 use_china_server: bool = False
+                 ) -> None:
         # Allow override Chia server from environment
         if os.getenv("MIDEA_CHINA_SERVER", "0") == "1":
             use_china_server = True
 
-        self._account = account
-        self._password = password
+        # Validate incoming credentials and region
+        if account and password:
+            self._account = account
+            self._password = password
+        elif account or password:
+            raise ValueError("Account and password must be specified.")
+        else:
+            try:
+                self._account, self._password = CLOUD_CREDENTIALS[region]
+            except KeyError:
+                raise ValueError(f"Unknown cloud region '{region}'.")
 
         # Attributes that holds the login information of the current user
         self._login_id = None

--- a/msmart/cloud.py
+++ b/msmart/cloud.py
@@ -13,7 +13,7 @@ import httpx
 from Crypto.Cipher import AES
 from Crypto.Util import Padding
 
-from msmart.const import DeviceType, CLOUD_CREDENTIALS
+from msmart.const import CLOUD_CREDENTIALS, DEFAULT_CLOUD_REGION, DeviceType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class Cloud:
     RETRIES = 3
 
     def __init__(self,
-                 region: str = "US",
+                 region: str = DEFAULT_CLOUD_REGION,
                  *,
                  account: Optional[str] = None,
                  password: Optional[str] = None,

--- a/msmart/const.py
+++ b/msmart/const.py
@@ -22,7 +22,7 @@ DEVICE_INFO_MSG = bytes([
     0xb7, 0xe4, 0x2d, 0x53, 0x49, 0x47, 0x62, 0xbe
 ])
 
-
+DEFAULT_CLOUD_REGION = "US"
 CLOUD_CREDENTIALS = {
     "DE": ("midea_eu@mailinator.com", "das_ist_passwort1"),
     "KR": ("midea_sea@mailinator.com", "password_for_sea1"),

--- a/msmart/const.py
+++ b/msmart/const.py
@@ -23,8 +23,11 @@ DEVICE_INFO_MSG = bytes([
 ])
 
 
-OPEN_MIDEA_APP_ACCOUNT = "midea@mailinator.com"
-OPEN_MIDEA_APP_PASSWORD = "this_is_a_password1"
+CLOUD_CREDENTIALS = {
+    "DE": ("midea_eu@mailinator.com", "das_ist_passwort1"),
+    "KR": ("midea_sea@mailinator.com", "password_for_sea1"),
+    "US": ("midea@mailinator.com", "this_is_a_password1")
+}
 
 
 class DeviceType(IntEnum):

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -7,8 +7,7 @@ import xml.etree.ElementTree as ET
 from typing import Any, Optional, Type, cast
 
 from msmart.cloud import Cloud, CloudError
-from msmart.const import (DEVICE_INFO_MSG, DISCOVERY_MSG,
-                          OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD,
+from msmart.const import (CLOUD_CREDENTIALS, DEVICE_INFO_MSG, DISCOVERY_MSG,
                           DeviceType)
 from msmart.device import AirConditioner, Device
 from msmart.lan import AuthenticationError, Security
@@ -135,8 +134,8 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
 class Discover:
     """Discover Midea smart devices on the local network."""
 
-    _account = OPEN_MIDEA_APP_ACCOUNT
-    _password = OPEN_MIDEA_APP_PASSWORD
+    _account = CLOUD_CREDENTIALS["US"]
+    _password = CLOUD_CREDENTIALS["US"]
     _lock = None
     _cloud = None
     _auto_connect = False

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree as ET
 from typing import Any, Optional, Type, cast
 
 from msmart.cloud import Cloud, CloudError
-from msmart.const import (CLOUD_CREDENTIALS, DEVICE_INFO_MSG, DISCOVERY_MSG,
+from msmart.const import (DEFAULT_CLOUD_REGION, DEVICE_INFO_MSG, DISCOVERY_MSG,
                           DeviceType)
 from msmart.device import AirConditioner, Device
 from msmart.lan import AuthenticationError, Security
@@ -134,7 +134,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
 class Discover:
     """Discover Midea smart devices on the local network."""
 
-    _region = "US"
+    _region = DEFAULT_CLOUD_REGION
     _account = None
     _password = None
     _lock = None
@@ -147,12 +147,12 @@ class Discover:
         *,
         target=_IPV4_BROADCAST,
         timeout=5,
-        discovery_packets:int=3,
+        discovery_packets: int = 3,
         interface=None,
-        region: str = "US",
+        region: str = DEFAULT_CLOUD_REGION,
         account: Optional[str] = None,
         password: Optional[str] = None,
-        auto_connect:bool =True
+        auto_connect: bool = True
     ) -> list[Device]:
         """Discover devices via broadcast."""
 
@@ -163,13 +163,7 @@ class Discover:
         # Always use a new cloud connection
         cls._cloud = None
 
-        # # Validate incoming credentials and region
-        # if (account is None and password is None) and region not in CLOUD_CREDENTIALS:
-        #     raise ValueError(f"Unknown cloud region '{region}'.")
-        # elif account or password:
-        #     raise ValueError("Account and password must be specified.")
-
-        # Save cloud credentials
+        # Save cloud region and credentials
         cls._region = region
         cls._account = account
         cls._password = password
@@ -231,7 +225,8 @@ class Discover:
         async with cls._lock:
             # Create cloud connection if nonexistent
             if cls._cloud is None:
-                cloud = Cloud(cls._region, account=cls._account, password=cls._password)
+                cloud = Cloud(cls._region, account=cls._account,
+                              password=cls._password)
                 try:
                     await cloud.login()
                     cls._cloud = cloud

--- a/msmart/tests/test_cloud.py
+++ b/msmart/tests/test_cloud.py
@@ -1,14 +1,16 @@
 import unittest
 
 from msmart.cloud import ApiError, Cloud, CloudError
-from msmart.const import OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD
+from msmart.const import CLOUD_CREDENTIALS
+
+CLOUD_ACCOUNT, CLOUD_PASSWORD = CLOUD_CREDENTIALS["US"]
 
 
 class TestCloud(unittest.IsolatedAsyncioTestCase):
     # pylint: disable=protected-access
 
-    async def _login(self, account: str = OPEN_MIDEA_APP_ACCOUNT,
-                     password: str = OPEN_MIDEA_APP_PASSWORD) -> Cloud:
+    async def _login(self, account: str = CLOUD_ACCOUNT,
+                     password: str = CLOUD_PASSWORD) -> Cloud:
         client = Cloud(account, password)
         await client.login()
 
@@ -53,7 +55,7 @@ class TestCloud(unittest.IsolatedAsyncioTestCase):
     async def test_connect_exception(self) -> None:
         """Test that an exception is thrown when the cloud connection fails."""
 
-        client = Cloud(OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD)
+        client = Cloud(CLOUD_ACCOUNT, CLOUD_PASSWORD)
 
         # Override URL to an invalid domain
         client._base_url = "https://fake_server.invalid."

--- a/msmart/tests/test_cloud.py
+++ b/msmart/tests/test_cloud.py
@@ -1,17 +1,20 @@
 import unittest
+from typing import Any, Optional
 
 from msmart.cloud import ApiError, Cloud, CloudError
-from msmart.const import CLOUD_CREDENTIALS
-
-CLOUD_ACCOUNT, CLOUD_PASSWORD = CLOUD_CREDENTIALS["US"]
+from msmart.const import DEFAULT_CLOUD_REGION
 
 
 class TestCloud(unittest.IsolatedAsyncioTestCase):
     # pylint: disable=protected-access
 
-    async def _login(self, account: str = CLOUD_ACCOUNT,
-                     password: str = CLOUD_PASSWORD) -> Cloud:
-        client = Cloud(account, password)
+    async def _login(self,
+                     region: str = DEFAULT_CLOUD_REGION,
+                     *,
+                     account: Optional[str] = None,
+                     password: Optional[str] = None
+                     ) -> Cloud:
+        client = Cloud(region, account=account, password=password)
         await client.login()
 
         return client
@@ -25,10 +28,26 @@ class TestCloud(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(client._access_token)
 
     async def test_login_exception(self) -> None:
-        """Test that we can login to the cloud."""
+        """Test that bad credentials raise an exception."""
 
         with self.assertRaises(ApiError):
             await self._login(account="bad@account.com", password="not_a_password")
+
+    async def test_invalid_region(self) -> None:
+        """Test that an invalid region raise an exception."""
+
+        with self.assertRaises(ValueError):
+            await self._login("NOT_A_REGION")
+
+    async def test_invalid_credentials(self) -> None:
+        """Test that invalid credentials raise an exception."""
+
+        # Check that specifying only an account or password raises an error
+        with self.assertRaises(ValueError):
+            await self._login(account=None, password="some_password")
+
+        with self.assertRaises(ValueError):
+            await self._login(account="some_account", password=None)
 
     async def test_get_token(self) -> None:
         """Test that a token and key can be obtained from the cloud."""
@@ -55,7 +74,7 @@ class TestCloud(unittest.IsolatedAsyncioTestCase):
     async def test_connect_exception(self) -> None:
         """Test that an exception is thrown when the cloud connection fails."""
 
-        client = Cloud(CLOUD_ACCOUNT, CLOUD_PASSWORD)
+        client = Cloud(DEFAULT_CLOUD_REGION)
 
         # Override URL to an invalid domain
         client._base_url = "https://fake_server.invalid."


### PR DESCRIPTION
It appears the server are region locking accounts. This PR adds support for specifying a region which is used solely for selecting different built-in credentials. Close #176 