### PR TITLE
Revert "Scale binary energy values by an additional factor of 10"

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -1024,11 +1024,10 @@ class EnergyUsageResponse(Response):
                    100 * decode_bcd(d[1]) +
                    1 * decode_bcd(d[2]) +
                    0.01 * decode_bcd(d[3]))
-            # Scale binary energy by an extra power of 10. See mill1000/midea-msmart#174
             binary = ((d[0] << 24) +
                       (d[1] << 16) +
                       (d[2] << 8) +
-                      d[3]) / 100
+                      d[3]) / 10
             return bcd, binary
 
         def parse_power(d: bytes) -> tuple[float, float]:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -844,7 +844,7 @@ class TestGroupDataResponse(_TestResponseBase):
         """Test we decode binary energy usage responses correctly."""
         TEST_RESPONSES = {
             # https://github.com/mill1000/midea-ac-py/issues/204#issuecomment-2314705021
-            (15.04, .06, 279.5): bytes.fromhex("aa22ac00000000000803c1210144000005e00000000000000006000aeb000000487a5e"),
+            (150.4, .6, 279.5): bytes.fromhex("aa22ac00000000000803c1210144000005e00000000000000006000aeb000000487a5e"),
 
             # https://github.com/mill1000/midea-msmart/pull/116#issuecomment-2218753545
             (None, None, None): bytes.fromhex("aa20ac00000000000303c1210144000000000000000000000000000000000843bc"),

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -297,7 +297,7 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         """Test parsing of EnergyUsageResponses into device state with binary format."""
         TEST_RESPONSES = {
             # https://github.com/mill1000/midea-ac-py/issues/204#issuecomment-2314705021
-            (15.04, .06, 279.5): bytes.fromhex("aa22ac00000000000803c1210144000005e00000000000000006000aeb000000487a5e"),
+            (150.4, .6, 279.5): bytes.fromhex("aa22ac00000000000803c1210144000005e00000000000000006000aeb000000487a5e"),
 
             # https://github.com/mill1000/midea-msmart/pull/116#issuecomment-2218753545
             (None, None, None): bytes.fromhex("aa20ac00000000000303c1210144000000000000000000000000000000000843bc"),


### PR DESCRIPTION
Reverts mill1000/midea-msmart#180

Another user reported (https://github.com/mill1000/midea-ac-py/issues/276) that scaling by another factor of 10 is not correct for all devices.

Instead we'll keep the original scaling, and have midea-ac-py perform the scaling 