### PR TITLE
Add support auxilary/electric/emergency heat

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -550,6 +550,8 @@ class CapabilitiesResponse(Response):
                 reader("cool_mode", lambda v: v != 2),
                 reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9]),
                 reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9]),
+                reader("heat_aux_mode", lambda v: v == 9), # Heat & Aux
+                reader("aux_mode", lambda v: v == 9), # Aux only
             ],
             CapabilityId.PRESET_ECO: reader("eco", lambda v: v in [1, 2]),
             CapabilityId.PRESET_FREEZE_PROTECTION: reader("freeze_protection", get_value(1)),
@@ -750,6 +752,14 @@ class CapabilitiesResponse(Response):
     @property
     def auto_mode(self) -> bool:
         return self._capabilities.get("auto_mode", False)
+
+    @property
+    def heat_aux_mode(self) -> bool:
+        return self._capabilities.get("heat_aux_mode", False)
+
+    @property
+    def aux_mode(self) -> bool:
+        return self._capabilities.get("aux_mode", False)
 
     @property
     def eco(self) -> bool:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -760,6 +760,11 @@ class CapabilitiesResponse(Response):
     @property
     def aux_mode(self) -> bool:
         return self._capabilities.get("aux_mode", False)
+    
+    @property
+    def aux_electric_heat(self) -> bool:
+        # TODO How does electric aux heat differ from aux mode?
+        return self._capabilities.get("aux_electric_heat", False)
 
     @property
     def eco(self) -> bool:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -546,7 +546,8 @@ class CapabilitiesResponse(Response):
                 reader("humidity_manual_set", lambda v: v in [2, 3]),
             ],
             CapabilityId.MODES: [
-                reader("heat_mode", lambda v: v in [1, 2, 4, 6, 7, 9, 10, 11, 12, 13]),
+                reader("heat_mode", lambda v: v in [
+                       1, 2, 4, 6, 7, 9, 10, 11, 12, 13]),
                 reader("cool_mode", lambda v: v not in [2, 10, 12]),
                 reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9, 11, 13]),
                 reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9, 13]),

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -546,12 +546,12 @@ class CapabilitiesResponse(Response):
                 reader("humidity_manual_set", lambda v: v in [2, 3]),
             ],
             CapabilityId.MODES: [
-                reader("heat_mode", lambda v: v in [1, 2, 4, 6, 7, 9]),
-                reader("cool_mode", lambda v: v != 2),
-                reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9]),
-                reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9]),
+                reader("heat_mode", lambda v: v in [1, 2, 4, 6, 7, 9, 10, 11, 12, 13]),
+                reader("cool_mode", lambda v: v not in [2, 10, 12]),
+                reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9, 11, 13]),
+                reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9, 13]),
                 reader("heat_aux_mode", lambda v: v == 9),  # Heat & Aux
-                reader("aux_mode", lambda v: v == 9),  # Aux only
+                reader("aux_mode", lambda v: v in [9, 10, 11, 13]),  # Aux only
             ],
             CapabilityId.PRESET_ECO: reader("eco", lambda v: v in [1, 2]),
             CapabilityId.PRESET_FREEZE_PROTECTION: reader("freeze_protection", get_value(1)),

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -288,7 +288,7 @@ class SetStateCommand(Command):
         # Build swing mode byte
         swing_mode = 0x30 | (self.swing_mode & 0x3F)
 
-        # Build eco mode and purifier byte
+        # Build eco mode, purifier, and aux heat byte
         eco = 0x80 if self.eco else 0
         purifier = 0x20 if self.purifier else 0
         aux_heat = 0x08 if self.aux_heat else 0
@@ -550,7 +550,7 @@ class CapabilitiesResponse(Response):
                 reader("cool_mode", lambda v: v not in [2, 10, 12]),
                 reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9, 11, 13]),
                 reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9, 13]),
-                reader("heat_aux_mode", lambda v: v == 9),  # Heat & Aux
+                reader("aux_heat_mode", lambda v: v == 9),  # Heat & Aux
                 reader("aux_mode", lambda v: v in [9, 10, 11, 13]),  # Aux only
             ],
             CapabilityId.PRESET_ECO: reader("eco", lambda v: v in [1, 2]),
@@ -754,13 +754,13 @@ class CapabilitiesResponse(Response):
         return self._capabilities.get("auto_mode", False)
 
     @property
-    def heat_aux_mode(self) -> bool:
-        return self._capabilities.get("heat_aux_mode", False)
+    def aux_heat_mode(self) -> bool:
+        return self._capabilities.get("aux_heat_mode", False)
 
     @property
     def aux_mode(self) -> bool:
         return self._capabilities.get("aux_mode", False)
-    
+
     @property
     def aux_electric_heat(self) -> bool:
         # TODO How does electric aux heat differ from aux mode?

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -550,8 +550,8 @@ class CapabilitiesResponse(Response):
                 reader("cool_mode", lambda v: v != 2),
                 reader("dry_mode", lambda v: v in [0, 1, 5, 6, 9]),
                 reader("auto_mode", lambda v: v in [0, 1, 2, 7, 8, 9]),
-                reader("heat_aux_mode", lambda v: v == 9), # Heat & Aux
-                reader("aux_mode", lambda v: v == 9), # Aux only
+                reader("heat_aux_mode", lambda v: v == 9),  # Heat & Aux
+                reader("aux_mode", lambda v: v == 9),  # Aux only
             ],
             CapabilityId.PRESET_ECO: reader("eco", lambda v: v in [1, 2]),
             CapabilityId.PRESET_FREEZE_PROTECTION: reader("freeze_protection", get_value(1)),

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -258,6 +258,7 @@ class SetStateCommand(Command):
         self.purifier = False
         self.target_humidity = 40
         self.aux_heat = False
+        self.force_aux_heat = False
         self.independent_aux_heat = False
 
     def tobytes(self) -> bytes:  # pyright: ignore[reportIncompatibleMethodOverride] # nopep8
@@ -291,6 +292,7 @@ class SetStateCommand(Command):
         eco = 0x80 if self.eco else 0
         purifier = 0x20 if self.purifier else 0
         aux_heat = 0x08 if self.aux_heat else 0
+        force_aux_heat = 0x10 if self.force_aux_heat else 0
 
         # Build sleep, turbo and fahrenheit byte
         sleep = 0x01 if self.sleep else 0
@@ -326,7 +328,7 @@ class SetStateCommand(Command):
             # Follow me and alternate turbo mode
             follow_me | turbo_alt,
             # ECO mode, purifier/anion, and aux heat
-            eco | purifier | aux_heat,
+            eco | purifier | force_aux_heat | aux_heat,
             # Sleep mode, turbo mode and fahrenheit
             sleep | turbo | fahrenheit,
             # Unknown

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -967,6 +967,7 @@ class AirConditioner(Device):
             "current_energy_usage": self.current_energy_usage,
             "real_time_power_usage": self.real_time_power_usage,
             "rate_select": self.rate_select,
+            "aux_mode": self.aux_mode,
         }}
 
     # Deprecated methods and properties

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -134,6 +134,7 @@ class AirConditioner(Device):
         self._supports_purifier = True
         self._supports_humidity = False
         self._supports_target_humidity = False
+        self._supports_electric_aux_heat = False
         self._min_target_temperature = 16
         self._max_target_temperature = 30
 
@@ -308,6 +309,8 @@ class AirConditioner(Device):
         self._supports_display_control = res.display_control
         self._supports_filter_reminder = res.filter_reminder
         self._supports_purifier = res.anion
+
+        self._supports_electric_aux_heat = res.aux_electric_heat
 
         self._min_target_temperature = res.min_temperature
         self._max_target_temperature = res.max_temperature

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -550,7 +550,7 @@ class AirConditioner(Device):
             _LOGGER.warning(
                 "Device is not capable of rate select %r.", self._rate_select)
 
-        if self._aux_mode != AirConditioner.AuxHeatMode.AUX_ONLY and self._aux_mode not in self._supported_aux_modes:
+        if self._aux_mode != AirConditioner.AuxHeatMode.OFF and self._aux_mode not in self._supported_aux_modes:
             _LOGGER.warning(
                 "Device is not capable of aux mode %r.", self._aux_mode)
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -83,6 +83,11 @@ class AirConditioner(Device):
 
         DEFAULT = OFF
 
+    class AuxHeatMode(MideaIntEnum):
+        OFF = 0
+        AUX_HEAT = 1
+        AUX_ONLY = 2
+
     # Create a dict to map attributes to property values
     _PROPERTY_MAP = {
         PropertyId.BREEZE_AWAY: lambda s: s._breeze_mode == AirConditioner.BreezeMode.BREEZE_AWAY,
@@ -134,7 +139,6 @@ class AirConditioner(Device):
         self._supports_purifier = True
         self._supports_humidity = False
         self._supports_target_humidity = False
-        self._supports_electric_aux_heat = False
         self._min_target_temperature = 16
         self._max_target_temperature = 30
 
@@ -163,6 +167,9 @@ class AirConditioner(Device):
         self._breeze_mode = AirConditioner.BreezeMode.OFF
 
         self._ieco = False
+
+        self._aux_mode = AirConditioner.AuxHeatMode.OFF
+        self._supported_aux_modes = [AirConditioner.AuxHeatMode.OFF]
 
     def _update_state(self, res: Response) -> None:
         """Update the local state from a device state response."""
@@ -207,6 +214,13 @@ class AirConditioner(Device):
             self._purifier = res.purifier
 
             self._target_humidity = res.target_humidity
+
+            if res.independent_aux_heat:
+                self._aux_mode = AirConditioner.AuxHeatMode.AUX_ONLY
+            elif res.aux_heat:
+                self._aux_mode = AirConditioner.AuxHeatMode.AUX_HEAT
+            else:
+                self._aux_mode = AirConditioner.AuxHeatMode.OFF
 
         elif isinstance(res, PropertiesResponse):
             if (angle := res.get_property(PropertyId.SWING_LR_ANGLE)) is not None:
@@ -310,7 +324,14 @@ class AirConditioner(Device):
         self._supports_filter_reminder = res.filter_reminder
         self._supports_purifier = res.anion
 
-        self._supports_electric_aux_heat = res.aux_electric_heat
+        # Build list of supported aux heating modes
+        aux_modes = [AirConditioner.AuxHeatMode.OFF]
+        if res.aux_electric_heat or res.aux_heat_mode:
+            aux_modes.append(AirConditioner.AuxHeatMode.AUX_HEAT)
+        if res.aux_mode:
+            aux_modes.append(AirConditioner.AuxHeatMode.AUX_ONLY)
+
+        self._supported_aux_modes = aux_modes
 
         self._min_target_temperature = res.min_temperature
         self._max_target_temperature = res.max_temperature
@@ -529,6 +550,10 @@ class AirConditioner(Device):
             _LOGGER.warning(
                 "Device is not capable of rate select %r.", self._rate_select)
 
+        if self._aux_mode != AirConditioner.AuxHeatMode.AUX_ONLY and self._aux_mode not in self._supported_aux_modes:
+            _LOGGER.warning(
+                "Device is not capable of aux mode %r.", self._aux_mode)
+
         # Define function to return value or a default if value is None
         def or_default(v, d) -> Any: return v if v is not None else d
 
@@ -548,6 +573,8 @@ class AirConditioner(Device):
         cmd.follow_me = or_default(self._follow_me, False)
         cmd.purifier = or_default(self._purifier, False)
         cmd.target_humidity = or_default(self._target_humidity, 40)
+        cmd.aux_heat = self._aux_mode == AirConditioner.AuxHeatMode.AUX_HEAT
+        cmd.independent_aux_heat = self._aux_mode == AirConditioner.AuxHeatMode.AUX_ONLY
 
         # Process any state responses from the device
         for response in await self._send_command_get_responses(cmd):
@@ -899,6 +926,18 @@ class AirConditioner(Device):
     def rate_select(self, rate: RateSelect) -> None:
         self._rate_select = rate
         self._updated_properties.add(PropertyId.RATE_SELECT)
+
+    @property
+    def supported_aux_modes(self) -> list[AuxHeatMode]:
+        return self._supported_aux_modes
+
+    @property
+    def aux_mode(self) -> AuxHeatMode:
+        return self._aux_mode
+
+    @aux_mode.setter
+    def aux_mode(self, mode: AuxHeatMode) -> None:
+        self._aux_mode = mode
 
     def to_dict(self) -> dict:
         return {**super().to_dict(), **{

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -310,6 +310,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "eco": True,
             "freeze_protection": True, "heat_mode": True,
             "cool_mode": True, "dry_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "auto_mode": True,
             "swing_horizontal": True, "swing_vertical": True,
             "energy_stats": False, "energy_setting": False, "energy_bcd": False,
@@ -322,6 +323,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_CAPABILITIES = {
             "swing_horizontal": True, "swing_vertical": True, "swing_both": True,
             "dry_mode": True, "heat_mode": True, "cool_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "eco": True, "turbo": True, "freeze_protection": True,
             "fan_custom": False, "fan_silent": False, "fan_low": True,
             "fan_medium": True,  "fan_high": True, "fan_auto": True,
@@ -355,6 +357,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_RAW_CAPABILITIES = {
             "eco": True, "breezeless": False,
             "heat_mode": True, "cool_mode": True, "dry_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "auto_mode": True, "swing_horizontal": True, "swing_vertical": True,
             "energy_stats": False, "energy_setting": False, "energy_bcd": False,
             "turbo_heat": True, "turbo_cool": True,
@@ -372,6 +375,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_CAPABILITIES = {
             "swing_horizontal": True, "swing_vertical": True, "swing_both": True,
             "dry_mode": True, "heat_mode": True, "cool_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "eco": True, "turbo": True, "freeze_protection": False,
             "fan_custom": True, "fan_silent": True, "fan_low": True,
             "fan_medium": True,  "fan_high": True, "fan_auto": True,
@@ -398,6 +402,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_RAW_CAPABILITIES = {
             "eco": True, "heat_mode": False,
             "cool_mode": True, "dry_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "swing_horizontal": False, "swing_vertical": False,
             "filter_notice": True, "filter_clean": False, "turbo_heat": False,
             "turbo_cool": False,
@@ -411,6 +416,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_CAPABILITIES = {
             "swing_horizontal": False, "swing_vertical": False, "swing_both": False,
             "dry_mode": True, "heat_mode": False, "cool_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "eco": True, "turbo": False, "freeze_protection": False,
             "fan_custom": False, "fan_silent": False, "fan_low": True,
             "fan_medium": True,  "fan_high": True, "fan_auto": True,
@@ -437,6 +443,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         EXPECTED_RAW_CAPABILITIES = {
             "eco": True, "freeze_protection": False,
             "heat_mode": False, "cool_mode": True, "dry_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "swing_horizontal": False, "swing_vertical": True, "filter_notice": True,
             "filter_clean": False, "turbo_heat": False, "turbo_cool": True,
             "fan_custom": True, "fan_silent": False, "fan_low": False,
@@ -487,6 +494,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "eco": True,
             "breeze_control": True,
             "heat_mode": True, "cool_mode": True, "dry_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "swing_horizontal": True, "swing_vertical": True,
             "energy_stats": False, "energy_setting": False, "energy_bcd": False,
             "turbo_heat": True, "turbo_cool": True,
@@ -531,6 +539,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "eco": True,
             "breeze_control": True,
             "heat_mode": True, "cool_mode": True, "dry_mode": True, "auto_mode": True,
+            "aux_heat_mode": False, "aux_mode": False,
             "swing_horizontal": True, "swing_vertical": True,
             "energy_stats": False, "energy_setting": False, "energy_bcd": False,
             "turbo_heat": True, "turbo_cool": True,
@@ -554,6 +563,110 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "dry_mode": True, "heat_mode": True, "cool_mode": True, "auto_mode": True,
             "eco": True, "turbo": True, "freeze_protection": True,
             "fan_custom": True, "fan_silent": True, "fan_low": True,
+            "fan_medium": True,  "fan_high": True, "fan_auto": True,
+            "min_temperature": 16, "max_temperature": 30,
+            "display_control": False, "filter_reminder": False,
+            "anion": True, "rate_select_levels": None
+        }
+        # Check capabilities properties match
+        for prop in self.EXPECTED_PROPERTIES:
+            self.assertEqual(getattr(resp, prop),
+                             EXPECTED_CAPABILITIES[prop], prop)
+
+    def test_capabilities_aux_heat(self) -> None:
+        self.maxDiff = None
+        """Test that we decode capabilities that include aux heating support."""
+        # https://github.com/mill1000/midea-ac-py/issues/297#issuecomment-2622720960
+        TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
+            "aa29ac00000000000303b50514020109150201021a020101250207203c203c203c003402010101007b1d")
+
+        # Test case includes an unknown capability 0x40 that generates a log
+        with self.assertLogs("msmart", logging.DEBUG) as log:
+            resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
+            resp = cast(CapabilitiesResponse, resp)
+
+            # Check debug message is generated for some unsupported capabilities
+            self.assertRegex("\n".join(log.output),
+                             "Unsupported capability <CapabilityId.BODY_CHECK: 564>, Size: 1.")
+
+        EXPECTED_RAW_CAPABILITIES = {
+            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True,
+            "aux_heat_mode": True, "aux_mode": True,
+            'swing_horizontal': False, 'swing_vertical': False,
+            'turbo_heat': True, 'turbo_cool': True,
+            'cool_min_temperature': 16.0,
+            'cool_max_temperature': 30.0,
+            'auto_min_temperature': 16.0,
+            'auto_max_temperature': 30.0,
+            'heat_min_temperature': 16.0,
+            'heat_max_temperature': 30.0,
+            'decimals': False
+        }
+        # Ensure raw decoded capabilities match
+        self.assertEqual(resp._capabilities, EXPECTED_RAW_CAPABILITIES)
+
+        # Check if there are additional capabilities
+        self.assertEqual(resp.additional_capabilities, True)
+
+        # Additional capabilities response
+        TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
+            "aa2fac00000000000303b508100201051f020100300001001302010019020101390001009300010194000101000095ca")
+        
+        # Test case includes an unknown capability 0x40 that generates a log
+        with self.assertLogs("msmart", logging.DEBUG) as log:
+            additional_resp = self._test_build_response(
+                TEST_ADDITIONAL_CAPABILITIES_RESPONSE)
+            additional_resp = cast(CapabilitiesResponse, additional_resp)
+
+            # Check debug message is generated for some unsupported capabilities
+            self.assertRegex("\n".join(log.output),
+                             "Unsupported capability <CapabilityId.EMERGENT_HEAT_WIND: 147>, Size: 1.")
+            
+            self.assertRegex("\n".join(log.output),
+                             "Unsupported capability <CapabilityId.HEAT_PTC_WIND: 148>, Size: 1.")
+
+        EXPECTED_ADDITIONAL_RAW_CAPABILITIES = {
+            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False,
+            'humidity_auto_set': False, 'humidity_manual_set': False,
+            'smart_eye': False, 'freeze_protection': False,
+            'aux_electric_heat': True, 'self_clean': False
+        }
+        # Ensure raw decoded capabilities match
+        self.assertEqual(additional_resp._capabilities,
+                         EXPECTED_ADDITIONAL_RAW_CAPABILITIES)
+
+        # Ensure the additional capabilities response doesn't also want more capabilities
+        self.assertEqual(additional_resp.additional_capabilities, False)
+
+        # Check that merging the capabilities produced expected results
+        resp.merge(additional_resp)
+
+        EXPECTED_MERGED_RAW_CAPABILITIES = {
+            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True, 
+            "aux_heat_mode": True, "aux_mode": True,
+            'swing_horizontal': False, 'swing_vertical': False, 
+            'turbo_heat': True, 'turbo_cool': True, 
+            'cool_min_temperature': 16.0, 
+            'cool_max_temperature': 30.0, 
+            'auto_min_temperature': 16.0, 
+            'auto_max_temperature': 30.0, 
+            'heat_min_temperature': 16.0, 
+            'heat_max_temperature': 30.0, 
+            'decimals': False, 
+            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False, 
+            'humidity_auto_set': False, 'humidity_manual_set': False, 
+            'smart_eye': False, 'freeze_protection': False, 
+            'aux_electric_heat': True, 'self_clean': False
+            }
+        # Ensure raw decoded capabilities match
+        self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
+
+        EXPECTED_CAPABILITIES = {
+            "swing_horizontal": False, "swing_vertical": False, "swing_both": False,
+            "dry_mode": True, "heat_mode": True, "cool_mode": True, "auto_mode": True,
+            "aux_heat_mode": True, "aux_mode": True,
+            "eco": False, "turbo": True, "freeze_protection": False,
+            "fan_custom": False, "fan_silent": False, "fan_low": True,
             "fan_medium": True,  "fan_high": True, "fan_auto": True,
             "min_temperature": 16, "max_temperature": 30,
             "display_control": False, "filter_reminder": False,

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -611,7 +611,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         # Additional capabilities response
         TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
             "aa2fac00000000000303b508100201051f020100300001001302010019020101390001009300010194000101000095ca")
-        
+
         # Test case includes an unknown capability 0x40 that generates a log
         with self.assertLogs("msmart", logging.DEBUG) as log:
             additional_resp = self._test_build_response(
@@ -621,7 +621,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             # Check debug message is generated for some unsupported capabilities
             self.assertRegex("\n".join(log.output),
                              "Unsupported capability <CapabilityId.EMERGENT_HEAT_WIND: 147>, Size: 1.")
-            
+
             self.assertRegex("\n".join(log.output),
                              "Unsupported capability <CapabilityId.HEAT_PTC_WIND: 148>, Size: 1.")
 
@@ -642,22 +642,22 @@ class TestCapabilitiesResponse(_TestResponseBase):
         resp.merge(additional_resp)
 
         EXPECTED_MERGED_RAW_CAPABILITIES = {
-            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True, 
+            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True,
             "aux_heat_mode": True, "aux_mode": True,
-            'swing_horizontal': False, 'swing_vertical': False, 
-            'turbo_heat': True, 'turbo_cool': True, 
-            'cool_min_temperature': 16.0, 
-            'cool_max_temperature': 30.0, 
-            'auto_min_temperature': 16.0, 
-            'auto_max_temperature': 30.0, 
-            'heat_min_temperature': 16.0, 
-            'heat_max_temperature': 30.0, 
-            'decimals': False, 
-            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False, 
-            'humidity_auto_set': False, 'humidity_manual_set': False, 
-            'smart_eye': False, 'freeze_protection': False, 
+            'swing_horizontal': False, 'swing_vertical': False,
+            'turbo_heat': True, 'turbo_cool': True,
+            'cool_min_temperature': 16.0,
+            'cool_max_temperature': 30.0,
+            'auto_min_temperature': 16.0,
+            'auto_max_temperature': 30.0,
+            'heat_min_temperature': 16.0,
+            'heat_max_temperature': 30.0,
+            'decimals': False,
+            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False,
+            'humidity_auto_set': False, 'humidity_manual_set': False,
+            'smart_eye': False, 'freeze_protection': False,
             'aux_electric_heat': True, 'self_clean': False
-            }
+        }
         # Ensure raw decoded capabilities match
         self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
 

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -495,6 +495,29 @@ class TestCapabilities(unittest.TestCase):
         self.assertEqual(device.supports_breeze_mild, False)
         self.assertEqual(device.supports_breezeless, True)
 
+    def test_aux_heat(self) -> None:
+        """Test aux heat mode capabilities."""
+
+        # https://github.com/mill1000/midea-ac-py/issues/297#issuecomment-2622720960
+        CAPABILITIES_PAYLOAD_0 = bytes.fromhex(
+            "b50514020109150201021a020101250207203c203c203c00340201010100")
+        CAPABILITIES_PAYLOAD_1 = bytes.fromhex(
+            "b508100201051f0201003000010013020100190201013900010093000101940001010000")
+
+        # Create a dummy device and process the response
+        device = AC(0, 0, 0)
+
+        # Parse capability payloads
+        with memoryview(CAPABILITIES_PAYLOAD_0) as payload0, memoryview(CAPABILITIES_PAYLOAD_1) as payload1:
+            resp0 = CapabilitiesResponse(payload0)
+            resp1 = CapabilitiesResponse(payload1)
+
+            resp0.merge(resp1)
+            device._update_capabilities(resp0)
+
+        self.assertEqual(device.supported_aux_modes, [
+                         AC.AuxHeatMode.OFF, AC.AuxHeatMode.AUX_HEAT, AC.AuxHeatMode.AUX_ONLY])
+
 
 class TestSetState(unittest.TestCase):
     """Test setting device state."""


### PR DESCRIPTION
Add support for auxiliary/electric heat when supported by the device. From what I can gather there are 2 operating modes for aux heat. 
* Regular mode -> Electric heater is used as needed
* Forced mode ("independent" aux heat) -> Only use electric heater