### PR TITLE
Add device ID to log messages to improve debugging multuiple devicest at once

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -492,6 +492,10 @@ class CapabilitiesResponse(Response):
 
         self._parse_capabilities(payload)
 
+    @property
+    def raw_capabilities(self) -> Mapping[str, Any]:
+        return self._capabilities
+
     def _parse_capabilities(self, payload: memoryview) -> None:
         # Clear existing capabilities
         self._capabilities.clear()

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -420,6 +420,9 @@ class Response():
         self._id = payload[0]
         self._payload = bytes(payload)
 
+    def __str__(self) -> str:
+        return self.payload.hex()
+
     @property
     def id(self) -> int:
         return self._id

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -487,11 +487,7 @@ class CapabilitiesResponse(Response):
         self._capabilities = {}
         self._additional_capabilities = False
 
-        _LOGGER.debug("Capabilities response payload: %s", payload.hex())
-
         self._parse_capabilities(payload)
-
-        _LOGGER.debug("Raw capabilities: %s", self._capabilities)
 
     def _parse_capabilities(self, payload: memoryview) -> None:
         # Clear existing capabilities
@@ -656,8 +652,6 @@ class CapabilitiesResponse(Response):
     def merge(self, other: CapabilitiesResponse) -> None:
         # Add other's capabilities to ours
         self._capabilities.update(other._capabilities)
-
-        _LOGGER.debug("Merged raw capabilities: %s", self._capabilities)
 
     @property
     def additional_capabilities(self) -> bool:
@@ -829,8 +823,6 @@ class StateResponse(Response):
         self.purifier = None
         self.target_humidity = None
 
-        _LOGGER.debug("State response payload: %s", payload.hex())
-
         self._parse(payload)
 
     def _parse(self, payload: memoryview) -> None:
@@ -937,8 +929,6 @@ class PropertiesResponse(Response):
 
         self._properties = {}
 
-        _LOGGER.debug("Properties response payload: %s", payload.hex())
-
         self._parse(payload)
 
     def _parse(self, payload: memoryview) -> None:
@@ -1008,8 +998,6 @@ class EnergyUsageResponse(Response):
         self.current_energy_binary = None
         self.real_time_power_binary = None
 
-        _LOGGER.debug("Energy response payload: %s", payload.hex())
-
         self._parse(payload)
 
     def _parse(self, payload: memoryview) -> None:
@@ -1076,8 +1064,6 @@ class HumidityResponse(Response):
         super().__init__(payload)
 
         self.humidity = None
-
-        _LOGGER.debug("Humidity response payload: %s", payload.hex())
 
         self._parse(payload)
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -431,7 +431,7 @@ class AirConditioner(Device):
 
         _LOGGER.debug("Capabilities response payload from device %s: %s",
                       self.id, response)
-        # _LOGGER.debug("Raw capabilities: %s", self._capabilities)
+        _LOGGER.debug("Raw capabilities: %s", response.raw_capabilities)
 
         # Send 2nd capabilities request if needed
         if response.additional_capabilities:
@@ -447,7 +447,8 @@ class AirConditioner(Device):
                 # Merge additional capabilities
                 response.merge(additional_response)
 
-                # _LOGGER.debug("Merged raw capabilities: %s", self._capabilities)
+                _LOGGER.debug("Merged raw capabilities: %s",
+                              response.raw_capabilities)
 
             else:
                 _LOGGER.warning(

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -168,7 +168,7 @@ class AirConditioner(Device):
 
         if isinstance(res, StateResponse):
             _LOGGER.debug("State response payload from device %s: %s",
-                          self.id, res.payload.hex())
+                          self.id, res)
 
             self._power_state = res.power_on
 
@@ -212,7 +212,7 @@ class AirConditioner(Device):
 
         elif isinstance(res, PropertiesResponse):
             _LOGGER.debug(
-                "Properties response payload from device %s: %s", self.id, res.payload.hex())
+                "Properties response payload from device %s: %s", self.id, res)
 
             if (angle := res.get_property(PropertyId.SWING_LR_ANGLE)) is not None:
                 self._horizontal_swing_angle = cast(
@@ -250,7 +250,7 @@ class AirConditioner(Device):
 
         elif isinstance(res, EnergyUsageResponse):
             _LOGGER.debug("Energy response payload from device %s: %s",
-                          self.id, res.payload.hex())
+                          self.id, res)
 
             self._total_energy_usage = res.total_energy_binary if self._use_binary_energy else res.total_energy
             self._current_energy_usage = res.current_energy_binary if self._use_binary_energy else res.current_energy
@@ -258,13 +258,13 @@ class AirConditioner(Device):
 
         elif isinstance(res, HumidityResponse):
             _LOGGER.debug(
-                "Humidity response payload from device %s: %s", self.id, res.payload.hex())
+                "Humidity response payload from device %s: %s", self.id, res)
 
             self._indoor_humidity = res.humidity
 
         else:
             _LOGGER.debug("Ignored unknown response from device %s: %s",
-                          self.id, res.payload.hex())
+                          self.id, res)
 
     def _update_capabilities(self, res: CapabilitiesResponse) -> None:
         # Build list of supported operation modes
@@ -412,7 +412,7 @@ class AirConditioner(Device):
                 return response
 
             _LOGGER.debug("Ignored response with ID %d from device %s: %s",
-                          response.id, self.id, response.payload.hex())
+                          response.id, self.id, response)
 
         return None
 
@@ -430,7 +430,7 @@ class AirConditioner(Device):
             return
 
         _LOGGER.debug("Capabilities response payload from device %s: %s",
-                      self.id, response.payload.hex())
+                      self.id, response)
         # _LOGGER.debug("Raw capabilities: %s", self._capabilities)
 
         # Send 2nd capabilities request if needed
@@ -442,7 +442,7 @@ class AirConditioner(Device):
 
             if additional_response:
                 _LOGGER.debug(
-                    "Additional capabilities response payload from device %s: %s", self.id, response.payload.hex())
+                    "Additional capabilities response payload from device %s: %s", self.id, response)
 
                 # Merge additional capabilities
                 response.merge(additional_response)

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -167,6 +167,9 @@ class AirConditioner(Device):
         """Update the local state from a device state response."""
 
         if isinstance(res, StateResponse):
+            _LOGGER.debug("State response payload from device %s: %s",
+                          self.id, res.payload.hex())
+
             self._power_state = res.power_on
 
             self._target_temperature = res.target_temperature
@@ -208,6 +211,9 @@ class AirConditioner(Device):
             self._target_humidity = res.target_humidity
 
         elif isinstance(res, PropertiesResponse):
+            _LOGGER.debug(
+                "Properties response payload from device %s: %s", self.id, res.payload.hex())
+
             if (angle := res.get_property(PropertyId.SWING_LR_ANGLE)) is not None:
                 self._horizontal_swing_angle = cast(
                     AirConditioner.SwingAngle,
@@ -243,16 +249,22 @@ class AirConditioner(Device):
                 self._ieco = value
 
         elif isinstance(res, EnergyUsageResponse):
+            _LOGGER.debug("Energy response payload from device %s: %s",
+                          self.id, res.payload.hex())
+
             self._total_energy_usage = res.total_energy_binary if self._use_binary_energy else res.total_energy
             self._current_energy_usage = res.current_energy_binary if self._use_binary_energy else res.current_energy
             self._real_time_power_usage = res.real_time_power_binary if self._use_binary_energy else res.real_time_power
 
         elif isinstance(res, HumidityResponse):
+            _LOGGER.debug(
+                "Humidity response payload from device %s: %s", self.id, res.payload.hex())
+
             self._indoor_humidity = res.humidity
 
         else:
-            _LOGGER.debug("Ignored unknown response from %s:%d: %s",
-                          self.ip, self.port, res.payload.hex())
+            _LOGGER.debug("Ignored unknown response from device %s: %s",
+                          self.id, res.payload.hex())
 
     def _update_capabilities(self, res: CapabilitiesResponse) -> None:
         # Build list of supported operation modes
@@ -399,8 +411,8 @@ class AirConditioner(Device):
             if response.id == response_id:
                 return response
 
-            _LOGGER.debug("Ignored response with ID %d from %s:%d: %s",
-                          response.id, self.ip, self.port, response.payload.hex())
+            _LOGGER.debug("Ignored response with ID %d from device %s: %s",
+                          response.id, self.id, response.payload.hex())
 
         return None
 
@@ -414,8 +426,12 @@ class AirConditioner(Device):
 
         if response is None:
             _LOGGER.error(
-                "Failed to query capabilities from %s:%d.", self.ip, self.port)
+                "Failed to query capabilities from device %s.", self.id)
             return
+
+        _LOGGER.debug("Capabilities response payload from device %s: %s",
+                      self.id, response.payload.hex())
+        # _LOGGER.debug("Raw capabilities: %s", self._capabilities)
 
         # Send 2nd capabilities request if needed
         if response.additional_capabilities:
@@ -425,11 +441,17 @@ class AirConditioner(Device):
                 CapabilitiesResponse, additional_response)
 
             if additional_response:
+                _LOGGER.debug(
+                    "Additional capabilities response payload from device %s: %s", self.id, response.payload.hex())
+
                 # Merge additional capabilities
                 response.merge(additional_response)
+
+                # _LOGGER.debug("Merged raw capabilities: %s", self._capabilities)
+
             else:
                 _LOGGER.warning(
-                    "Failed to query additional capabilities from %s:%d.", self.ip, self.port)
+                    "Failed to query additional capabilities from device %s.", self.id)
 
         # Update device capabilities
         self._update_capabilities(response)
@@ -438,7 +460,8 @@ class AirConditioner(Device):
         """Toggle the device display if the device supports it."""
 
         if not self._supports_display_control:
-            _LOGGER.warning("Device is not capable of display control.")
+            _LOGGER.warning(
+                "Device %s is not capable of display control.", self.id)
 
         cmd = ToggleDisplayCommand()
         cmd.beep_on = self._beep_on
@@ -486,7 +509,8 @@ class AirConditioner(Device):
 
         # Warn if attempting to update a property that isn't supported
         for prop in (properties.keys() - self._supported_properties):
-            _LOGGER.warning("Device is not capable of property %r.", prop)
+            _LOGGER.warning(
+                "Device %s is not capable of property %r.", self.id, prop)
 
         # Always add buzzer property
         properties[PropertyId.BUZZER] = self._beep_on
@@ -502,29 +526,30 @@ class AirConditioner(Device):
         # Warn if trying to apply unsupported modes
         if self._operational_mode not in self._supported_op_modes:
             _LOGGER.warning(
-                "Device is not capable of operational mode %r.", self._operational_mode)
+                "Device %s is not capable of operational mode %r.",  self.id, self._operational_mode)
 
         if (self._fan_speed not in self._supported_fan_speeds
                 and not self._supports_custom_fan_speed):
             _LOGGER.warning(
-                "Device is not capable of fan speed %r.", self._fan_speed)
+                "Device %s is not capable of fan speed %r.",  self.id, self._fan_speed)
 
         if self._swing_mode not in self._supported_swing_modes:
             _LOGGER.warning(
-                "Device is not capable of swing mode %r.", self._swing_mode)
+                "Device %s is not capable of swing mode %r.",  self.id, self._swing_mode)
 
         if self._turbo and not self._supports_turbo:
-            _LOGGER.warning("Device is not capable of turbo mode.")
+            _LOGGER.warning("Device %s is not capable of turbo mode.", self.id)
 
         if self._eco and not self._supports_eco:
-            _LOGGER.warning("Device is not capable of eco mode.")
+            _LOGGER.warning("Device %s is not capable of eco mode.",  self.id)
 
         if self._freeze_protection and not self._supports_freeze_protection:
-            _LOGGER.warning("Device is not capable of freeze protection.")
+            _LOGGER.warning(
+                "Device %s is not capable of freeze protection.", self.id)
 
         if self._rate_select != AirConditioner.RateSelect.OFF and self._rate_select not in self._supported_rate_selects:
             _LOGGER.warning(
-                "Device is not capable of rate select %r.", self._rate_select)
+                "Device %s is not capable of rate select %r.",  self.id, self._rate_select)
 
         # Define function to return value or a default if value is None
         def or_default(v, d) -> Any: return v if v is not None else d


### PR DESCRIPTION
When debugging midea-ac-py, users often have multiple devices which can make it difficult to associate certain log reports with specific devices.

This PR adds the device ID to most the warnings and response payload messages.
