### PR TITLE
Update discovery flow to throw exceptions when cloud connection fails

### DIFF
--- a/msmart/cloud.py
+++ b/msmart/cloud.py
@@ -114,8 +114,8 @@ class BaseCloud:
                         retries -= 1
                     else:
                         raise CloudError("No response from server.") from e
-                except httpx.RequestError as e:
-                    raise CloudError("Request failed.") from e
+                except httpx.HTTPError as e:
+                    raise CloudError(f"HTTP request failed: {e}") from e
 
     async def _api_request(self, endpoint: str, body: dict[str, Any]) -> Optional[dict]:
         """Make a request to the cloud and return the results."""

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -240,7 +240,7 @@ class Discover:
                     await cloud.login()
                     cls._cloud = cloud
                 except CloudError as e:
-                    raise DiscoverError(
+                    raise CloudError(
                         f"Failed to login to cloud. {e}") from e
 
         return cls._cloud
@@ -369,7 +369,7 @@ class Discover:
         # Get cloud connection
         try:
             cloud = await Discover._get_cloud()
-        except DiscoverError as e:
+        except CloudError as e:
             _LOGGER.error("Could not establish cloud connection. Error: %s", e)
             raise e
 

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -225,7 +225,7 @@ class Discover:
         """Return a cloud connection, creating it if necessary."""
 
         # Lock should exist by now
-        assert (cls._lock)
+        assert cls._lock
 
         async with cls._lock:
             # Create cloud connection if nonexistent
@@ -240,7 +240,8 @@ class Discover:
                     await cloud.login()
                     cls._cloud = cloud
                 except CloudError as e:
-                    _LOGGER.error("Failed to login to cloud. Error: %s", e)
+                    raise DiscoverError(
+                        f"Failed to login to cloud. {e}") from e
 
         return cls._cloud
 
@@ -366,15 +367,18 @@ class Discover:
         """Attempt to authenticate a V3 device."""
 
         # Get cloud connection
-        cloud = await Discover._get_cloud()
-        if cloud is None:
-            _LOGGER.error("Could not establish cloud connection.")
-            return False
+        try:
+            cloud = await Discover._get_cloud()
+        except DiscoverError as e:
+            _LOGGER.error("Could not establish cloud connection. Error: %s", e)
+            raise e
+
+        assert cloud
 
         # Try authenticating with udpids generated from both endians
         for endian in ["little", "big"]:
-            udpid = Security.udpid(dev.id.to_bytes(
-                6, endian)).hex()  # type: ignore
+            udpid = Security.udpid(
+                dev.id.to_bytes(6, endian)).hex()  # type: ignore
 
             _LOGGER.debug(
                 "Fetching token and key for udpid '%s' (%s).", udpid, endian)


### PR DESCRIPTION
Allowing CloudErrors to propagate up will allow better error reporting for users of HA