### PR TITLE
Use GeoIP to select cloud region in GH Action unittests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -48,3 +48,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install --editable .
       - run: python -m unittest
+
+      - name: Breakpoint if tests failed
+        if: failure()
+        uses: namespacelabs/breakpoint-action@v0
+        with:
+          duration: 30m
+          authorized-users: midea, password

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GH_USE_GEOIP: 1
+
 jobs:
   check-autopep8-isort:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11, 3.12, 3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.11, 3.12, 3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,4 +54,4 @@ jobs:
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 30m
-          authorized-users: midea, password
+          authorized-users: mill1000

--- a/msmart/tests/test_cloud.py
+++ b/msmart/tests/test_cloud.py
@@ -1,22 +1,81 @@
-import logging
 import unittest
-from typing import Any, Optional, cast
+import httpx
+import os
+from typing import Optional, cast
 
 from msmart.cloud import (ApiError, BaseCloud, CloudError, NetHomePlusCloud,
                           SmartHomeCloud)
 from msmart.const import DEFAULT_CLOUD_REGION
 
+_EU_COUNTRY_CODES = [
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK",
+    "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+    "IT", "LV", "LT", "LU", "MT", "NL", "PL",
+    "PT", "RO", "SK", "SI", "ES", "SE", "GB"
+]
+
 
 class TestCloud(unittest.IsolatedAsyncioTestCase):
     # pylint: disable=protected-access
 
+    _region = None
+
+    @classmethod
+    def set_region(cls, region):
+        """Set the region class attribute so its common for all testcases"""
+        cls._region = region
+
+    async def _get_region(self) -> str:
+        """Get approximate region for Cloud credentials using GeoIP lookup."""
+
+        # Get IP address from ipify
+        async with httpx.AsyncClient() as client:
+            r = await client.get("https://api.ipify.org?format=json")
+            r.raise_for_status()
+
+        ip = r.json()["ip"]
+
+        # Get geolocation from ip-api
+        async with httpx.AsyncClient() as client:
+            r = httpx.get(
+                f"http://ip-api.com/json/{ip}?fields=status,country,countryCode,query")
+            r.raise_for_status()
+
+        geo_ip = r.json()
+        self.assertEqual(geo_ip["status"], "success")
+
+        # Check if region is vaguely European
+        country_code = geo_ip["countryCode"]
+        return "DE" if country_code in _EU_COUNTRY_CODES else DEFAULT_CLOUD_REGION
+
+    async def asyncSetUp(self):
+        """Setup cloud test class."""
+
+        # Don't setup region twice
+        if self._region is not None:
+            return
+
+        # Use GeoIP to estimate region if env enables it
+        if os.getenv("GH_USE_GEOIP", "0") == "1":
+            region = await self._get_region()
+        else:
+            region = DEFAULT_CLOUD_REGION
+
+        self.set_region(region)
+
     async def _login(self,
                      class_name,
                      *,
-                     region: str = DEFAULT_CLOUD_REGION,
+                     region: str = None,
                      account: Optional[str] = None,
                      password: Optional[str] = None
                      ) -> BaseCloud:
+        """Create a cloud instance and login."""
+
+        # Allow argument to override predetermined region
+        if region is None:
+            region = self._region
+
         client = class_name(region, account=account, password=password)
         await client.login()
 
@@ -27,6 +86,7 @@ class TestNetHomePlusCloud(TestCloud):
     # pylint: disable=protected-access
 
     async def _login(self, *args, **kwargs) -> NetHomePlusCloud:
+        """Create a cloud instance and login."""
         client = await super()._login(NetHomePlusCloud, *args, **kwargs)
         return cast(NetHomePlusCloud, client)
 
@@ -72,7 +132,7 @@ class TestNetHomePlusCloud(TestCloud):
         self.assertIsNotNone(key)
 
     async def test_get_token_exception(self) -> None:
-        """Test that an exception is thrown when a token and key 
+        """Test that an exception is thrown when a token and key
         can't be obtained from the cloud."""
 
         BAD_UDPID = "NOT_A_UDPID"
@@ -98,6 +158,7 @@ class TestSmartHomeCloud(TestCloud):
     # pylint: disable=protected-access
 
     async def _login(self, *args, **kwargs) -> SmartHomeCloud:
+        """Create a cloud instance and login."""
         client = await super()._login(SmartHomeCloud, *args, **kwargs)
         return cast(SmartHomeCloud, client)
 

--- a/msmart/tests/test_cloud.py
+++ b/msmart/tests/test_cloud.py
@@ -1,7 +1,8 @@
-import unittest
-import httpx
 import os
+import unittest
 from typing import Optional, cast
+
+import httpx
 
 from msmart.cloud import (ApiError, BaseCloud, CloudError, NetHomePlusCloud,
                           SmartHomeCloud)


### PR DESCRIPTION
The EU region appears to be the most locked down, and we can't specify where our GH runners are running, so this attempts to fix that.

When enabled by the `GH_USE_GEOIP` env variable, the cloud testcases will attempt to determine their region by using the APIs from ipify.com and ip-api.com to determine a country code. This is compared against a rough list of EU countries and the region code is set accordingly.