### PR TITLE
Update pyproject licensing to be compliant with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   {name = "Tucker Kern", email = "tuckkern@gmail.com"},
 ]
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
@@ -18,7 +18,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Topic :: Home Automation"
 ]


### PR DESCRIPTION
Should resolve the following warnings in builds
```
#29 3.637 /tmp/build-env-wq4qrbw7/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
#29 3.637 !!
#29 3.637 
#29 3.637         ********************************************************************************
#29 3.637         Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
#29 3.637 
#29 3.637         By 2026-Feb-18, you need to update your project and remove deprecated calls
#29 3.637         or your builds will no longer be supported.
#29 3.637 
#29 3.637         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
#29 3.637         ********************************************************************************
#29 3.637 
#29 3.637 !!
#29 3.637   corresp(dist, value, root_dir)
#29 4.036 /tmp/build-env-wq4qrbw7/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
#29 4.036 !!
#29 4.036 
#29 4.036         ********************************************************************************
#29 4.036         Please consider removing the following classifiers in favor of a SPDX license expression:
#29 4.036 
#29 4.036         License :: OSI Approved :: MIT License
#29 4.036 
#29 4.036         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
#29 4.036         ********************************************************************************
#29 4.036 
#29 4.036 !!
```