### PR TITLE
Use class instead of ID to filter for specific responses

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -491,7 +491,7 @@ class AirConditioner(Device):
                 if not isinstance(additional_response, CapabilitiesResponse):
                     _LOGGER.error(
                         "Unexpected response to additional capabilities request from device %s: %s.", self.id, additional_response)
-                    
+
                 _LOGGER.debug(
                     "Additional capabilities response payload from device %s: %s", self.id, additional_response)
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -472,6 +472,10 @@ class AirConditioner(Device):
                 "Failed to query capabilities from device %s.", self.id)
             return
 
+        if not isinstance(response, CapabilitiesResponse):
+            _LOGGER.error(
+                "Unexpected response to capabilities request from device %s: %s.", self.id, response)
+
         _LOGGER.debug("Capabilities response payload from device %s: %s",
                       self.id, response)
         _LOGGER.debug("Raw capabilities: %s", response.raw_capabilities)
@@ -484,6 +488,10 @@ class AirConditioner(Device):
                 CapabilitiesResponse, additional_response)
 
             if additional_response:
+                if not isinstance(additional_response, CapabilitiesResponse):
+                    _LOGGER.error(
+                        "Unexpected response to additional capabilities request from device %s: %s.", self.id, additional_response)
+                    
                 _LOGGER.debug(
                     "Additional capabilities response payload from device %s: %s", self.id, additional_response)
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -475,6 +475,7 @@ class AirConditioner(Device):
         if not isinstance(response, CapabilitiesResponse):
             _LOGGER.error(
                 "Unexpected response to capabilities request from device %s: %s.", self.id, response)
+            return
 
         _LOGGER.debug("Capabilities response payload from device %s: %s",
                       self.id, response)
@@ -488,19 +489,18 @@ class AirConditioner(Device):
                 CapabilitiesResponse, additional_response)
 
             if additional_response:
-                if not isinstance(additional_response, CapabilitiesResponse):
+                if isinstance(additional_response, CapabilitiesResponse):
+                    _LOGGER.debug(
+                        "Additional capabilities response payload from device %s: %s", self.id, additional_response)
+
+                    # Merge additional capabilities
+                    response.merge(additional_response)
+
+                    _LOGGER.debug("Merged raw capabilities: %s",
+                                  response.raw_capabilities)
+                else:
                     _LOGGER.error(
                         "Unexpected response to additional capabilities request from device %s: %s.", self.id, additional_response)
-
-                _LOGGER.debug(
-                    "Additional capabilities response payload from device %s: %s", self.id, additional_response)
-
-                # Merge additional capabilities
-                response.merge(additional_response)
-
-                _LOGGER.debug("Merged raw capabilities: %s",
-                              response.raw_capabilities)
-
             else:
                 _LOGGER.warning(
                     "Failed to query additional capabilities from device %s.", self.id)

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -677,6 +677,27 @@ class TestSendCommandGetResponse(unittest.IsolatedAsyncioTestCase):
             # Assert device is still online
             self.assertEqual(device.online, True)
 
+    async def test_get_capabilities_bad_response(self):
+        """Test that get_capabilities() with any invalid response outputs an error."""
+        TEST_RESPONSE = bytes.fromhex(
+            "aa1aac00000000000205b50310060101090001010a000101dcbcb4")
+
+        # Create a dummy device
+        device = AC(0, 0, 0)
+
+        # Patch _send_command to return a valid state response
+        with patch("msmart.base_device.Device._send_command", return_value=[TEST_RESPONSE]) as patched_method:
+
+            # Get device capabilities
+            with self.assertLogs("msmart", logging.ERROR) as log:
+                await device.get_capabilities()
+
+                self.assertRegex("\n".join(log.output),
+                                 "Unexpected response to capabilities request.*")
+
+            # Assert patch method was awaited
+            patched_method.assert_awaited()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -664,7 +664,7 @@ class TestSendCommandGetResponse(unittest.IsolatedAsyncioTestCase):
             device._online = True
             self.assertEqual(device.online, True)
 
-            # Force additional features so refresh() sends multuple requests are sent
+            # Force additional features so refresh() sends multiple requests are sent
             device._request_energy_usage = True
             device._supports_humidity = True
 
@@ -678,22 +678,24 @@ class TestSendCommandGetResponse(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(device.online, True)
 
     async def test_get_capabilities_bad_response(self):
-        """Test that get_capabilities() with any invalid response outputs an error."""
+        """Test that get_capabilities() with any unexpected response outputs an error."""
         TEST_RESPONSE = bytes.fromhex(
             "aa1aac00000000000205b50310060101090001010a000101dcbcb4")
 
         # Create a dummy device
         device = AC(0, 0, 0)
 
-        # Patch _send_command to return a valid state response
+        # Patch _send_command to return test response
         with patch("msmart.base_device.Device._send_command", return_value=[TEST_RESPONSE]) as patched_method:
-
             # Get device capabilities
-            with self.assertLogs("msmart", logging.ERROR) as log:
+            with self.assertLogs("msmart", logging.DEBUG) as log:
                 await device.get_capabilities()
 
                 self.assertRegex("\n".join(log.output),
-                                 "Unexpected response to capabilities request.*")
+                                 "Failed to query capabilities from device.*")
+
+                self.assertRegex("\n".join(log.output),
+                                 "Ignored response of type.*from device.*")
 
             # Assert patch method was awaited
             patched_method.assert_awaited()

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -679,6 +679,8 @@ class TestSendCommandGetResponse(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_capabilities_bad_response(self):
         """Test that get_capabilities() with any unexpected response outputs an error."""
+        # "Notify" response with the same ID as capabilities response
+        # https://github.com/mill1000/midea-msmart/issues/122#issue-2281252018
         TEST_RESPONSE = bytes.fromhex(
             "aa1aac00000000000205b50310060101090001010a000101dcbcb4")
 


### PR DESCRIPTION
It appears a user is getting back responses with IDs that match capabilities responses by the response is constructed as a base Response object.

This is likely due to #123 

However it's causing occasion errors for users when we try to access the non-existent `raw_capabilities` attribute.

https://github.com/mill1000/midea-ac-py/issues/358#issuecomment-3171895494