### PR TITLE
Add support for accessing individual energy data fields in either format

### DIFF
--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -162,10 +162,19 @@ class AirConditioner(Device):
         self._outdoor_temperature = None
 
         self._request_energy_usage = False
-        self._total_energy_usage = {AirConditioner.EnergyDataFormat.BCD: None, AirConditioner.EnergyDataFormat.BINARY: None}
-        self._current_energy_usage = {AirConditioner.EnergyDataFormat.BCD: None, AirConditioner.EnergyDataFormat.BINARY: None}
-        self._real_time_power_usage = {AirConditioner.EnergyDataFormat.BCD: None, AirConditioner.EnergyDataFormat.BINARY: None}
-        self._use_binary_energy = False # Deprecated
+        self._total_energy_usage = {
+            AirConditioner.EnergyDataFormat.BCD: None,
+            AirConditioner.EnergyDataFormat.BINARY: None,
+        }
+        self._current_energy_usage = {
+            AirConditioner.EnergyDataFormat.BCD: None,
+            AirConditioner.EnergyDataFormat.BINARY: None,
+        }
+        self._real_time_power_usage = {
+            AirConditioner.EnergyDataFormat.BCD: None,
+            AirConditioner.EnergyDataFormat.BINARY: None,
+        }
+        self._use_binary_energy = False  # Deprecated
 
         # Default to assuming device can't handle any properties
         self._supported_properties = set()
@@ -1105,12 +1114,12 @@ class AirConditioner(Device):
         self.turbo = enabled
 
     @property
-    @deprecated("", msg = "Use format argument of get_*_energy_usage methods.")
+    @deprecated("", msg="Use format argument of get_*_energy_usage methods.")
     def use_alternate_energy_format(self) -> bool:
         return self._use_binary_energy
 
     @use_alternate_energy_format.setter
-    @deprecated("", msg = "Use format argument of get_*_energy_usage methods.")
+    @deprecated("", msg="Use format argument of get_*_energy_usage methods.")
     def use_alternate_energy_format(self, enable: bool) -> None:
         self._use_binary_energy = enable
 

--- a/msmart/utils.py
+++ b/msmart/utils.py
@@ -50,7 +50,8 @@ def deprecated(replacement: str, msg: Optional[str] = None) -> Callable[[Callabl
             # Check if already warned
             if not getattr(func, "_warn_deprecate", False):
                 logger = logging.getLogger(func.__module__)
-                logger.warning("'%s' is deprecated. %s", func.__name__, (msg or f"Please use '{replacement}' instead."))
+                logger.warning("'%s' is deprecated. %s", func.__name__,
+                               (msg or f"Please use '{replacement}' instead."))
                 setattr(func, "_warn_deprecate", True)
 
             return func(*args, **kwargs)

--- a/msmart/utils.py
+++ b/msmart/utils.py
@@ -37,7 +37,7 @@ class MideaIntEnum(IntEnum):
             return cls(default)
 
 
-def deprecated(replacement: str) -> Callable[[Callable], Callable]:
+def deprecated(replacement: str, msg: Optional[str] = None) -> Callable[[Callable], Callable]:
     """Mark function as deprecated and recommend a replacement."""
 
     def deprecated_decorator(func: Callable) -> Callable:
@@ -50,10 +50,7 @@ def deprecated(replacement: str) -> Callable[[Callable], Callable]:
             # Check if already warned
             if not getattr(func, "_warn_deprecate", False):
                 logger = logging.getLogger(func.__module__)
-                logger.warning("'%s' is deprecated. Please use '%s' instead.",
-                               func.__name__,
-                               replacement,
-                               )
+                logger.warning("'%s' is deprecated. %s", func.__name__, (msg or f"Please use '{replacement}' instead."))
                 setattr(func, "_warn_deprecate", True)
 
             return func(*args, **kwargs)


### PR DESCRIPTION
Add methods to fetch total energy, current energy and real time power in either data format.

Deprecate existing properties and the `use_alternative_energy_format` property.