### PR TITLE
Validate frame length

### DIFF
--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1250,6 +1250,14 @@ class TestResponseConstruct(_TestResponseBase):
         self.assertIsNotNone(resp)
         self.assertEqual(type(resp), PropertiesResponse)
 
+    def test_short_packet(self) -> None:
+        """Test that a short frame raise exceptions."""
+        # https://github.com/mill1000/midea-msmart/issues/234#issuecomment-3299199631
+        TEST_RESPONSE_SHORT_FRAME = bytes.fromhex("01000000")
+
+        with self.assertRaises(InvalidFrameException):
+            Response.construct(TEST_RESPONSE_SHORT_FRAME)
+
 
 class TestGroupDataResponse(_TestResponseBase):
     """Test group data response messages."""

--- a/msmart/frame.py
+++ b/msmart/frame.py
@@ -49,6 +49,10 @@ class Frame():
 
     @classmethod
     def validate(cls, frame: memoryview) -> None:
+        # Ensure length is sane
+        if len(frame) < cls._HEADER_LENGTH:
+            raise InvalidFrameException(f"Frame is too short: {frame.hex()}")
+
         # Validate frame checksum
         checksum = Frame.checksum(frame[1:-1])
         if checksum != frame[-1]:


### PR DESCRIPTION
Add a length check to received frames before checking the checksum. The user in #234 has devices that are returning bogus responses which pass checksums (all 0s) but throw index errors since they are too short.