### PR TITLE
Add support for Out Silent Mode (Capability 0x00CD) for Midea PortaSplit

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -69,6 +69,7 @@ class CapabilityId(IntEnum):
     TWINS_MACHINE = 0x0232  # ??
     GUIDE_STRIP_TYPE = 0x0233  # ??
     BODY_CHECK = 0x0234  # ??
+    OUT_SILENT = 0x00CD
 
 
 class PropertyId(IntEnum):
@@ -86,6 +87,7 @@ class PropertyId(IntEnum):
     JET_COOL = 0x0067  # AKA "Flash Cool"
     IECO = 0x00E3
     ANION = 0x021E
+    OUT_SILENT = 0x00CD # PortaSplit OutSilentMode
 
     @property
     def _supported(self) -> bool:
@@ -102,6 +104,7 @@ class PropertyId(IntEnum):
             PropertyId.SELF_CLEAN,
             PropertyId.SWING_LR_ANGLE,
             PropertyId.SWING_UD_ANGLE,
+            PropertyId.OUT_SILENT,
         ]
 
     def decode(self, data: bytes) -> Any:
@@ -109,8 +112,10 @@ class PropertyId(IntEnum):
         if not self._supported:
             raise NotImplementedError(f"{repr(self)} decode is not supported.")
 
-        if self in [PropertyId.BREEZELESS, PropertyId.JET_COOL, PropertyId.SELF_CLEAN,]:
+        if self in [PropertyId.BREEZELESS, PropertyId.JET_COOL, PropertyId.SELF_CLEAN]:
             return bool(data[0])
+        elif self == PropertyId.OUT_SILENT:
+            return data[0] == 3
         elif self == PropertyId.BREEZE_AWAY:
             return data[0] == 2
         elif self == PropertyId.BUZZER:
@@ -131,6 +136,8 @@ class PropertyId(IntEnum):
 
         if self == PropertyId.BREEZE_AWAY:
             return bytes([2 if args[0] else 1])
+        elif self == PropertyId.OUT_SILENT:
+            return bytes([3 if args[0] else 0])
         elif self == PropertyId.IECO:
             # ieco_frame, ieco_number, ieco_switch, ...
             return bytes([0, 1, args[0]]) + bytes(10)
@@ -592,6 +599,7 @@ class CapabilitiesResponse(Response):
             # CapabilityId.TEMPERATURES too complex to be handled here
             CapabilityId.WIND_OFF_ME:  reader("wind_off_me", get_value(1)),
             CapabilityId.WIND_ON_ME:  reader("wind_on_me", get_value(1)),
+            CapabilityId.OUT_SILENT: reader("out_silent", get_value(1)),
             # CapabilityId._UNKNOWN is a special case
         }
 
@@ -692,6 +700,10 @@ class CapabilitiesResponse(Response):
     @property
     def anion(self) -> bool:
         return self._capabilities.get("anion", False)
+    
+    @property
+    def out_silent(self) -> bool:
+        return self._capabilities.get("out_silent", False)
 
     # TODO rethink these properties for fan speed, operation mode and swing mode
     # Surely there's a better way than define props for each possible cap

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -43,11 +43,12 @@ class CapabilityId(IntEnum):
     PREVENT_STRAIGHT_WIND_SELECT = 0x0058  # ??
     CASCADE = 0x0059  # AKA "Wind Around"
     JET_COOL = 0x0067  # ??
-    PRESET_IECO = 0x00E3
     ICHECK = 0x0091  # ??
     EMERGENT_HEAT_WIND = 0x0093  # ??
     HEAT_PTC_WIND = 0x0094  # ??
     CVP = 0x0098  # ??
+    OUT_SILENT = 0x00CD  # Portasplit outdoor silent mode
+    PRESET_IECO = 0x00E3
     FAN_SPEED_CONTROL = 0x0210
     PRESET_ECO = 0x0212
     PRESET_FREEZE_PROTECTION = 0x0213
@@ -69,7 +70,6 @@ class CapabilityId(IntEnum):
     TWINS_MACHINE = 0x0232  # ??
     GUIDE_STRIP_TYPE = 0x0233  # ??
     BODY_CHECK = 0x0234  # ??
-    OUT_SILENT = 0x00CD
 
 
 class PropertyId(IntEnum):
@@ -85,9 +85,9 @@ class PropertyId(IntEnum):
     FRESH_AIR = 0x004B
     CASCADE = 0x0059  # AKA "Wind Around"
     JET_COOL = 0x0067  # AKA "Flash Cool"
+    OUT_SILENT = 0x00CD  # Portasplit outdoor silent mode
     IECO = 0x00E3
     ANION = 0x021E
-    OUT_SILENT = 0x00CD # PortaSplit OutSilentMode
 
     @property
     def _supported(self) -> bool:
@@ -100,11 +100,11 @@ class PropertyId(IntEnum):
             PropertyId.CASCADE,
             PropertyId.IECO,
             PropertyId.JET_COOL,
+            PropertyId.OUT_SILENT,
             PropertyId.RATE_SELECT,
             PropertyId.SELF_CLEAN,
             PropertyId.SWING_LR_ANGLE,
             PropertyId.SWING_UD_ANGLE,
-            PropertyId.OUT_SILENT,
         ]
 
     def decode(self, data: bytes) -> Any:
@@ -114,18 +114,18 @@ class PropertyId(IntEnum):
 
         if self in [PropertyId.BREEZELESS, PropertyId.JET_COOL, PropertyId.SELF_CLEAN]:
             return bool(data[0])
-        elif self == PropertyId.OUT_SILENT:
-            return data[0] == 3
         elif self == PropertyId.BREEZE_AWAY:
             return data[0] == 2
         elif self == PropertyId.BUZZER:
             return None  # Don't decode buzzer
-        elif self == PropertyId.IECO:
-            # data[0] - ieco_number, data[1] - ieco_switch
-            return bool(data[1])
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return data[1] if data[0] else 0
+        elif self == PropertyId.IECO:
+            # data[0] - ieco_number, data[1] - ieco_switch
+            return bool(data[1])
+        elif self == PropertyId.OUT_SILENT:
+            return data[0] == 3
         else:
             return data[0]
 
@@ -136,14 +136,14 @@ class PropertyId(IntEnum):
 
         if self == PropertyId.BREEZE_AWAY:
             return bytes([2 if args[0] else 1])
-        elif self == PropertyId.OUT_SILENT:
-            return bytes([3 if args[0] else 0])
-        elif self == PropertyId.IECO:
-            # ieco_frame, ieco_number, ieco_switch, ...
-            return bytes([0, 1, args[0]]) + bytes(10)
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return bytes([1 if args[0] else 0, args[0]])
+        elif self == PropertyId.IECO:
+            # ieco_frame, ieco_number, ieco_switch, ...
+            return bytes([0, 1, args[0]]) + bytes(10)
+        elif self == PropertyId.OUT_SILENT:
+            return bytes([3 if args[0] else 0])
         else:
             return bytes(args[0:1])
 
@@ -576,6 +576,7 @@ class CapabilitiesResponse(Response):
                 reader("aux_heat_mode", lambda v: v == 9),  # Heat & Aux
                 reader("aux_mode", lambda v: v in [9, 10, 11, 13]),  # Aux only
             ],
+            CapabilityId.OUT_SILENT: reader("out_silent", lambda v: v in [1, 3]),
             CapabilityId.PRESET_ECO: reader("eco", lambda v: v in [1, 2]),
             CapabilityId.PRESET_FREEZE_PROTECTION: reader("freeze_protection", get_value(1)),
             CapabilityId.PRESET_IECO: reader("ieco", get_value(1)),
@@ -599,7 +600,6 @@ class CapabilitiesResponse(Response):
             # CapabilityId.TEMPERATURES too complex to be handled here
             CapabilityId.WIND_OFF_ME:  reader("wind_off_me", get_value(1)),
             CapabilityId.WIND_ON_ME:  reader("wind_on_me", get_value(1)),
-            CapabilityId.OUT_SILENT: reader("out_silent", lambda v: v in [1, 3]),
             # CapabilityId._UNKNOWN is a special case
         }
 
@@ -679,7 +679,7 @@ class CapabilitiesResponse(Response):
         # Check if there are additional capabilities
         if len(caps) > 1:
             self._additional_capabilities = bool(caps[-2])
-    
+
     def _get_fan_speed(self, speed) -> bool:
         # If any fan_ capability was received, check against them
         if any(k.startswith("fan_") for k in self._capabilities):
@@ -700,10 +700,6 @@ class CapabilitiesResponse(Response):
     @property
     def anion(self) -> bool:
         return self._capabilities.get("anion", False)
-    
-    @property
-    def out_silent(self) -> bool:
-        return self._capabilities.get("out_silent", False)
 
     # TODO rethink these properties for fan speed, operation mode and swing mode
     # Surely there's a better way than define props for each possible cap
@@ -862,6 +858,10 @@ class CapabilitiesResponse(Response):
             return 2
 
         return None
+
+    @property
+    def out_silent(self) -> bool:
+        return self._capabilities.get("out_silent", False)
 
 
 class StateResponse(Response):

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -599,7 +599,7 @@ class CapabilitiesResponse(Response):
             # CapabilityId.TEMPERATURES too complex to be handled here
             CapabilityId.WIND_OFF_ME:  reader("wind_off_me", get_value(1)),
             CapabilityId.WIND_ON_ME:  reader("wind_on_me", get_value(1)),
-            CapabilityId.OUT_SILENT: reader("out_silent", get_value(1)),
+            CapabilityId.OUT_SILENT: reader("out_silent", lambda v: v in [1, 3]),
             # CapabilityId._UNKNOWN is a special case
         }
 
@@ -679,7 +679,7 @@ class CapabilitiesResponse(Response):
         # Check if there are additional capabilities
         if len(caps) > 1:
             self._additional_capabilities = bool(caps[-2])
-
+    
     def _get_fan_speed(self, speed) -> bool:
         # If any fan_ capability was received, check against them
         if any(k.startswith("fan_") for k in self._capabilities):

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -134,6 +134,7 @@ class AirConditioner(Device):
         JET_COOL = auto()
         PURIFIER = auto()
         SELF_CLEAN = auto()
+        OUT_SILENT = auto()
 
         DEFAULT = (
             CUSTOM_FAN_SPEED |
@@ -153,6 +154,7 @@ class AirConditioner(Device):
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
         PropertyId.SWING_UD_ANGLE: lambda s: s._vertical_swing_angle,
         PropertyId.CASCADE: lambda s: s._cascade_mode,
+        PropertyId.OUT_SILENT: lambda s: s._out_silent,
     }
 
     _SUPPORTED_CAPABILITY_OVERRIDES = {
@@ -196,6 +198,7 @@ class AirConditioner(Device):
         self._purifier = False
         self._ieco = False
         self._flash_cool = False
+        self._out_silent = False
 
         self._horizontal_swing_angle = AirConditioner.SwingAngle.OFF
         self._vertical_swing_angle = AirConditioner.SwingAngle.OFF
@@ -355,6 +358,9 @@ class AirConditioner(Device):
             if (value := res.get_property(PropertyId.JET_COOL)) is not None:
                 self._flash_cool = value
 
+            if (value := res.get_property(PropertyId.OUT_SILENT)) is not None:
+                self._out_silent = value
+
         elif isinstance(res, EnergyUsageResponse):
             _LOGGER.debug("Energy response payload from device %s: %s",
                           self.id, res)
@@ -470,6 +476,9 @@ class AirConditioner(Device):
 
         self._capabilities.set(
             AirConditioner.Capability.SELF_CLEAN, res.self_clean)
+        
+        self._capabilities.set(
+            AirConditioner.Capability.OUT_SILENT, res.out_silent)
 
         # Add supported rate select levels
         if (rates := res.rate_select_levels) is not None:
@@ -531,6 +540,8 @@ class AirConditioner(Device):
         # Rate select is a special case. It's property based but not controlled by a capability flag
         if self._supported_rate_selects != [AirConditioner.RateSelect.OFF]:
             self._supported_properties.add(PropertyId.RATE_SELECT)
+
+        self._supported_properties.add(PropertyId.OUT_SILENT)
 
     async def _send_commands_get_responses(self, commands: Union[Command, list[Command]]) -> list[Response]:
         """Send a list of commands and return all valid responses."""
@@ -1135,6 +1146,19 @@ class AirConditioner(Device):
     @property
     def outdoor_fan_speed(self) -> Optional[int]:
         return self._outdoor_fan_speed
+    
+    @property
+    def supports_out_silent(self) -> bool:
+        return self._capabilities.has(AirConditioner.Capability.OUT_SILENT)
+
+    @property
+    def out_silent(self) -> Optional[bool]:
+        return self._out_silent
+
+    @out_silent.setter
+    def out_silent(self, enabled: bool) -> None:
+        self._out_silent = enabled
+        self._updated_properties.add(PropertyId.OUT_SILENT)
 
     def to_dict(self) -> dict:
         return {**super().to_dict(), **{
@@ -1161,6 +1185,7 @@ class AirConditioner(Device):
             "follow_me": self.follow_me,
             "purifier": self.purifier,
             "self_clean": self.self_clean_active,
+            "out_silent": self.out_silent,
             "total_energy_usage": self.get_total_energy_usage(),
             "current_energy_usage": self.get_current_energy_usage(),
             "real_time_power_usage": self.get_real_time_power_usage(),

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -525,6 +525,7 @@ class AirConditioner(Device):
             AirConditioner.Capability.IECO: PropertyId.IECO,
             AirConditioner.Capability.JET_COOL: PropertyId.JET_COOL,
             AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
+            AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
             AirConditioner.Capability.SWING_HORIZONTAL_ANGLE: PropertyId.SWING_LR_ANGLE,
             AirConditioner.Capability.SWING_VERTICAL_ANGLE: PropertyId.SWING_UD_ANGLE,
         }
@@ -540,8 +541,6 @@ class AirConditioner(Device):
         # Rate select is a special case. It's property based but not controlled by a capability flag
         if self._supported_rate_selects != [AirConditioner.RateSelect.OFF]:
             self._supported_properties.add(PropertyId.RATE_SELECT)
-
-        self._supported_properties.add(PropertyId.OUT_SILENT)
 
     async def _send_commands_get_responses(self, commands: Union[Command, list[Command]]) -> list[Response]:
         """Send a list of commands and return all valid responses."""

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -132,9 +132,9 @@ class AirConditioner(Device):
         # Misc
         CASCADE = auto()
         JET_COOL = auto()
+        OUT_SILENT = auto()
         PURIFIER = auto()
         SELF_CLEAN = auto()
-        OUT_SILENT = auto()
 
         DEFAULT = (
             CUSTOM_FAN_SPEED |
@@ -148,13 +148,13 @@ class AirConditioner(Device):
         PropertyId.BREEZE_AWAY: lambda s: s._breeze_mode == AirConditioner.BreezeMode.BREEZE_AWAY,
         PropertyId.BREEZE_CONTROL: lambda s: s._breeze_mode,
         PropertyId.BREEZELESS: lambda s: s._breeze_mode == AirConditioner.BreezeMode.BREEZELESS,
+        PropertyId.CASCADE: lambda s: s._cascade_mode,
         PropertyId.IECO: lambda s: s._ieco,
         PropertyId.JET_COOL: lambda s: s._flash_cool,
+        PropertyId.OUT_SILENT: lambda s: s._out_silent,
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
         PropertyId.SWING_UD_ANGLE: lambda s: s._vertical_swing_angle,
-        PropertyId.CASCADE: lambda s: s._cascade_mode,
-        PropertyId.OUT_SILENT: lambda s: s._out_silent,
     }
 
     _SUPPORTED_CAPABILITY_OVERRIDES = {
@@ -473,9 +473,6 @@ class AirConditioner(Device):
 
         self._capabilities.set(
             AirConditioner.Capability.SELF_CLEAN, res.self_clean)
-        
-        self._capabilities.set(
-            AirConditioner.Capability.OUT_SILENT, res.out_silent)
 
         # Add supported rate select levels
         if (rates := res.rate_select_levels) is not None:
@@ -508,6 +505,9 @@ class AirConditioner(Device):
         self._capabilities.set(
             AirConditioner.Capability.JET_COOL, res.jet_cool)
 
+        self._capabilities.set(
+            AirConditioner.Capability.OUT_SILENT, res.out_silent)
+
         # Update supported properties from capabilities
         self._update_supported_properties()
 
@@ -521,8 +521,8 @@ class AirConditioner(Device):
             AirConditioner.Capability.CASCADE: PropertyId.CASCADE,
             AirConditioner.Capability.IECO: PropertyId.IECO,
             AirConditioner.Capability.JET_COOL: PropertyId.JET_COOL,
-            AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
             AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
+            AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
             AirConditioner.Capability.SWING_HORIZONTAL_ANGLE: PropertyId.SWING_LR_ANGLE,
             AirConditioner.Capability.SWING_VERTICAL_ANGLE: PropertyId.SWING_UD_ANGLE,
         }
@@ -1142,7 +1142,7 @@ class AirConditioner(Device):
     @property
     def outdoor_fan_speed(self) -> Optional[int]:
         return self._outdoor_fan_speed
-    
+
     @property
     def supports_out_silent(self) -> bool:
         return self._capabilities.has(AirConditioner.Capability.OUT_SILENT)
@@ -1181,7 +1181,6 @@ class AirConditioner(Device):
             "follow_me": self.follow_me,
             "purifier": self.purifier,
             "self_clean": self.self_clean_active,
-            "out_silent": self.out_silent,
             "total_energy_usage": self.get_total_energy_usage(),
             "current_energy_usage": self.get_current_energy_usage(),
             "real_time_power_usage": self.get_real_time_power_usage(),
@@ -1189,6 +1188,7 @@ class AirConditioner(Device):
             "aux_mode": self.aux_mode,
             "error_code": self.error_code,
             "defrost": self.defrost_active,
+            "out_silent": self.out_silent,
         }}
 
     def capabilities_dict(self) -> dict:

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1005,9 +1005,8 @@ class TestCapabilitiesResponse(_TestResponseBase):
         resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
         resp = cast(CapabilitiesResponse, resp)
 
-        # Ensure OUT_SILENT is decoded as True from the specific value 3
-        self.assertTrue(resp._capabilities.get("out_silent"))
-        self.assertTrue(getattr(resp, "out_silent"))
+        self.assertIn("out_silent", resp._capabilities)
+        self.assertEqual(resp.out_silent, True)
 
 
 class TestGetPropertiesCommand(unittest.TestCase):

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -260,7 +260,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
         "display_control", "filter_reminder",
         "min_temperature", "max_temperature",
         "energy_stats", "humidity", "target_humidity", "self_clean",
-        "rate_select_levels",
+        "rate_select_levels", "out_silent"
     ]
 
     def test_properties(self) -> None:
@@ -364,7 +364,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -426,7 +426,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -477,7 +477,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -530,7 +530,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -643,7 +643,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": True,
             "target_humidity": True, "self_clean": True,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -758,7 +758,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -871,7 +871,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": True, "humidity": False,
             "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
@@ -988,12 +988,26 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "min_temperature": 16.0, "max_temperature": 30.0,
             "energy_stats": False, "humidity": True,
             "target_humidity": True, "self_clean": True,
-            "rate_select_levels": None,
+            "rate_select_levels": None, "out_silent": False
         }
         # Check capabilities properties match
         for prop in self.EXPECTED_ATTRS:
             self.assertEqual(getattr(resp, prop),
                              EXPECTED_CAPABILITIES[prop], prop)
+
+    def test_capabilities_out_silent(self) -> None:
+        """Test that we decode the OUT_SILENT capability correctly from a real PortaSplit payload."""
+        # Real payload from a PortaSplit device containing ID 0x00CD with value 0x03
+        TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
+            "aa2fac00000000000803b5081f0201002c020101160201043900010151000101e300010113020101cd0001030002365b"
+        )
+
+        resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
+        resp = cast(CapabilitiesResponse, resp)
+
+        # Ensure OUT_SILENT is decoded as True from the specific value 3
+        self.assertTrue(resp._capabilities.get("out_silent"))
+        self.assertTrue(getattr(resp, "out_silent"))
 
 
 class TestGetPropertiesCommand(unittest.TestCase):
@@ -1043,6 +1057,10 @@ class TestSetPropertiesCommand(unittest.TestCase):
             (PropertyId.CASCADE, 0): bytes([0, 0]),
             (PropertyId.CASCADE, 1): bytes([1, 1]),
             (PropertyId.CASCADE, 2): bytes([1, 2]),
+
+            # Out Silent: 0x03 - On, 0x00 - Off
+            (PropertyId.OUT_SILENT, True): bytes([0x03]),
+            (PropertyId.OUT_SILENT, False): bytes([0x00]),
         }
 
         for (prop, value), expected_data in TEST_ENCODES.items():
@@ -1107,6 +1125,10 @@ class TestPropertiesResponse(_TestResponseBase):
             (PropertyId.CASCADE, bytes([0x00, 0x00])): 0,
             (PropertyId.CASCADE, bytes([0x01, 0x01])): 1,
             (PropertyId.CASCADE, bytes([0x01, 0x02])): 2,
+
+            # Out Silent: 0x03 - On, 0x00 - Off
+            (PropertyId.OUT_SILENT, bytes([0x03])): True,
+            (PropertyId.OUT_SILENT, bytes([0x00])): False,
         }
 
         for (prop, data), expected_value in TEST_DECODES.items():

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -486,6 +486,22 @@ class TestCapabilities(unittest.TestCase):
         self.assertEqual(device.supported_aux_modes, [
                          AC.AuxHeatMode.OFF, AC.AuxHeatMode.AUX_HEAT, AC.AuxHeatMode.AUX_ONLY])
 
+    def test_out_silent(self) -> None:
+        """Test out silent capability."""
+        CAPABILITIES_PAYLOAD_0 = bytes.fromhex(
+            "b5081f0201002c020101160201043900010151000101e300010113020101cd000103000236")
+
+        # Create a dummy device and process the response
+        device = AC(0, 0, 0)
+
+        # Parse capability payloads
+        with memoryview(CAPABILITIES_PAYLOAD_0) as payload0:
+            resp0 = CapabilitiesResponse(payload0)
+
+            device._update_capabilities(resp0)
+
+        self.assertEqual(device.supports_out_silent, True)
+
 
 class TestSetState(unittest.TestCase):
     """Test setting device state."""

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -590,6 +590,22 @@ class TestSetState(unittest.TestCase):
         # Assert correct property is being updated
         self.assertIn(PropertyId.CASCADE, device._updated_properties)
 
+    def test_properties_out_silent(self) -> None:
+        """Test setting out silent property."""
+
+        # Create dummy device with out silent
+        device = AC(0, 0, 0)
+        device._capabilities.set(AC.Capability.OUT_SILENT)
+
+        # Enable out silent
+        device.out_silent = True
+
+        # Assert state is expected
+        self.assertEqual(device.out_silent, True)
+
+        # Assert correct property is being updated
+        self.assertIn(PropertyId.OUT_SILENT, device._updated_properties)
+
 
 class TestRefresh(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
Hi!

This PR adds support for the "Out Silent Mode" feature, which is primarily used by the Midea PortaSplit device. 
This addresses the feature request mentioned in [mill1000/midea-ac-py#404](https://github.com/mill1000/midea-ac-py/issues/404).

**Protocol Analysis & Payload Structure:**
During network analysis of the device communication, the following behavior for capability 0x00CD was identified:

- Activating the mode requires sending the byte 0x03.
- Deactivating the mode requires sending the byte 0x00.
- Sending a standard boolean 0x01 results in a 0x11 (invalid value) error code from the device.

**Implementation Details:**
Added `OUT_SILENT` to `CapabilityId` and `PropertyId`.

Implemented specific decoding and encoding logic in `command.py` to map boolean `True` to the required `0x03` byte and `False` to `0x00`.

**_FIXED_**
> Important workaround in `device.py`: While the device reports the capability `0x00CD` during discovery, the standard capability mapping drops it during the update cycle due to non standard reporting by the firmware. To ensure the property is reliably queried during every `refresh() `call and not blocked by the internal checks before sending the command, `PropertyId.OUT_SILENT` is explicitly appended to `self._supported_properties `inside `_update_supported_properties()`.


I have tested this locally on my PortaSplit device and the mode toggles reliably. Please let me know if any architectural adjustments are preferred for the hardcoded property workaround.

Best,
Thomas