### PR TITLE
Fix exception is discovery when device of unknown type is created

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -239,6 +239,9 @@ class Device():
     def construct(cls, *, type: DeviceType, **kwargs) -> Union[AirConditioner, CommercialAirConditioner, Device]:
         """Construct a device object based on the provided device type."""
 
+        # Remove possible duplicate device_type kwarg
+        kwargs.pop("device_type", None)
+
         if type == DeviceType.AIR_CONDITIONER:
             from msmart.device import AirConditioner
             return AirConditioner(**kwargs)

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -167,9 +167,6 @@ class AirConditioner(Device):
     }
 
     def __init__(self, ip: str, device_id: int,  port: int, **kwargs) -> None:
-        # Remove possible duplicate device_type kwarg
-        kwargs.pop("device_type", None)
-
         super().__init__(ip=ip, port=port, device_id=device_id,
                          device_type=DeviceType.AIR_CONDITIONER, **kwargs)
 

--- a/msmart/device/CC/device.py
+++ b/msmart/device/CC/device.py
@@ -121,9 +121,6 @@ class CommercialAirConditioner(Device):
     }
 
     def __init__(self, ip: str, device_id: int,  port: int, **kwargs) -> None:
-        # Remove possible duplicate device_type kwarg
-        kwargs.pop("device_type", None)
-
         super().__init__(ip=ip, port=port, device_id=device_id,
                          device_type=DeviceType.COMMERCIAL_AC, **kwargs)
 

--- a/msmart/tests/test_device.py
+++ b/msmart/tests/test_device.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from msmart.base_device import Device
 from msmart.const import DeviceType, FrameType
+from msmart.device import AirConditioner as AC
+from msmart.device import CommercialAirConditioner as CC
 from msmart.frame import Frame
 from msmart.lan import ProtocolError
 from msmart.utils import CapabilityManager
@@ -272,6 +274,72 @@ class TestOverrideCapabilities(unittest.TestCase):
         device.override_capabilities(
             {"additional_capabilities": ["TWO"]}, merge=False)
         self.assertEqual(device._dummy_attr, TestEnum.TWO)
+
+
+class TestConstruct(unittest.TestCase):
+    """Test construction of device instances."""
+
+    def test_construct_ac(self) -> None:
+        """Test construction of an AC device."""
+
+        DEVICE_INFO = {
+            "ip": "127.0.0.1",
+            "port": 6444,
+            "device_id": 147334558165565,
+            "device_type": DeviceType.AIR_CONDITIONER,
+            "name": "net_ac_63BA",
+            "sn": "000000P0000000Q1B88C29C963BA0000"
+        }
+        device = Device.construct(
+            type=DeviceType.AIR_CONDITIONER, **DEVICE_INFO)
+
+        self.assertIsNotNone(device)
+        self.assertIsInstance(device, AC)
+
+        self.assertEqual(device.ip, "127.0.0.1")
+        self.assertEqual(device.port, 6444)
+        self.assertEqual(device.id, 147334558165565)
+        self.assertEqual(device.sn, "000000P0000000Q1B88C29C963BA0000")
+
+    def test_construct_cc(self) -> None:
+        """Test construction of a CC device."""
+
+        DEVICE_INFO = {
+            "ip": "127.0.0.11",
+            "port": 6444,
+            "device_id": 123456,
+            "device_type": DeviceType.COMMERCIAL_AC,
+            "sn": "000000"
+        }
+        device = Device.construct(type=DeviceType.COMMERCIAL_AC, **DEVICE_INFO)
+
+        self.assertIsNotNone(device)
+        self.assertIsInstance(device, CC)
+
+        self.assertEqual(device.ip, "127.0.0.11")
+        self.assertEqual(device.port, 6444)
+        self.assertEqual(device.id, 123456)
+        self.assertEqual(device.sn, "000000")
+
+    def test_construct_unsupported(self) -> None:
+        """Test construction of an unsupported device."""
+
+        DEVICE_INFO = {
+            "ip": "127.0.0.22",
+            "port": 6666,
+            "device_id": 987654,
+            "device_type": 0xBD,
+            "sn": "12345"
+        }
+        device = Device.construct(type=0xBD, **DEVICE_INFO)
+
+        self.assertIsNotNone(device)
+        self.assertIsInstance(device, Device)
+
+        self.assertEqual(device.ip, "127.0.0.22")
+        self.assertEqual(device.port, 6666)
+        self.assertEqual(device.id, 987654)
+        self.assertEqual(device.sn, "12345")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ensures `device_type` is never passed as kwargs to device constructors.

Originally noted in [#401](https://github.com/mill1000/midea-ac-py/issues/401)

https://github.com/mill1000/midea-ac-py/issues/401#issuecomment-4142406327
```
DEBUG:msmart.discover:Discovered 4 devices.
Traceback (most recent call last):
  File "/usr/local/bin/msmart-ng", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/lib/python3.14/site-packages/msmart/cli.py", line 441, in main
    _run(parser.parse_args())
    ~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/msmart/cli.py", line 325, in _run
    asyncio.run(args.func(args))
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/asyncio/runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.14/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/msmart/cli.py", line 36, in _discover
    devices = await Discover.discover(region=args.region, account=args.account, password=args.password, discovery_packets=args.count)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/msmart/discover.py", line 199, in discover
    devices = await asyncio.gather(*protocol.tasks)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/msmart/discover.py", line 400, in _get_device
    dev = Device.construct(type=info["device_type"], **info)
  File "/usr/local/lib/python3.14/site-packages/msmart/base_device.py", line 243, in construct
    return Device(device_type=type, **kwargs)
TypeError: msmart.base_device.Device() got multiple values for keyword argument 'device_type'
```
