### PR TITLE
Add cloud relay fallback for C3 devices where getToken fails

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -1,10 +1,13 @@
 import logging
 import time
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from msmart.const import DeviceType
 from msmart.frame import Frame
 from msmart.lan import LAN, AuthenticationError, Key, ProtocolError, Token
+
+if TYPE_CHECKING:
+    from msmart.cloud import Cloud
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +25,7 @@ class Device():
         self._version = kwargs.get("version", None)
 
         self._lan = LAN(ip, port, device_id)
+        self._cloud: Optional["Cloud"] = None
         self._supported = False
         self._online = False
 
@@ -31,6 +35,15 @@ class Device():
         data = command.tobytes()
         _LOGGER.debug("Sending command to %s:%d: %s",
                       self.ip, self.port, data.hex())
+
+        # Use cloud relay when configured (e.g. LAN token unavailable)
+        if self._cloud is not None:
+            response = await self._cloud.appliance_transparent_send(self._id, data)
+            if response is None:
+                _LOGGER.warning("No response via cloud relay for %s:%d.", self.ip, self.port)
+                return None
+            _LOGGER.debug("Response via cloud relay from %s:%d.", self.ip, self.port)
+            return [response]
 
         start = time.time()
         responses = None
@@ -66,6 +79,15 @@ class Device():
             await self._lan.authenticate(token, key)
         except (ProtocolError, TimeoutError) as e:
             raise AuthenticationError(e) from e
+
+    def set_cloud(self, cloud: "Cloud") -> None:
+        """Configure cloud relay for all commands.
+
+        When set, commands are relayed through the Midea cloud API instead of
+        being sent directly over LAN. This is a fallback for devices whose LAN
+        token cannot be retrieved via getToken.
+        """
+        self._cloud = cloud
 
     def set_max_connection_lifetime(self, seconds: Optional[int]) -> None:
         """Set the maximum connection lifetime of the LAN protocol."""

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -147,12 +147,21 @@ async def _download(args) -> None:
 async def _control(args) -> None:
     """Control a heat pump device."""
 
-    _LOGGER.info("Connecting to %s.", args.host)
-    device = await Discover.discover_single(args.host, account=args.account, password=args.password)
+    if args.device_id:
+        # Construct device directly when ID is known (skips UDP discovery)
+        device = HeatPump(ip=args.host, port=6444, device_id=args.device_id, version=3)
+        Discover._lock = asyncio.Lock()
+        Discover._set_cloud_credentials(args.account, args.password)
+        if not await Discover.connect(device):
+            _LOGGER.error("Could not connect to device.")
+            exit(1)
+    else:
+        _LOGGER.info("Discovering %s on local network.", args.host)
+        device = await Discover.discover_single(args.host, account=args.account, password=args.password)
 
-    if device is None:
-        _LOGGER.error("Device not found.")
-        exit(1)
+        if device is None:
+            _LOGGER.error("Device not found.")
+            exit(1)
 
     if not isinstance(device, HeatPump):
         _LOGGER.error("Device at %s is not a heat pump (type=%s).", args.host, hex(device.type))
@@ -162,7 +171,7 @@ async def _control(args) -> None:
     if args.zone1_power is not None:
         device.zone1.power_state = args.zone1_power
     if args.temp is not None:
-        device.zone1.target_temperature = args.temp
+        device.zone1.target_temperature = int(args.temp)
     if args.mode is not None:
         device.run_mode = HeatPump.RunMode[args.mode.upper()]
 
@@ -267,6 +276,8 @@ def main() -> NoReturn:
                                            description="Control a heat pump device.",
                                            parents=[common_parser])
     control_parser.add_argument("host", help="Hostname or IP address of device.")
+    control_parser.add_argument("--id", dest="device_id", type=int, default=0,
+                                help="Device ID (skips UDP discovery, useful when broadcast doesn't work).")
     control_parser.add_argument("--on", dest="zone1_power", action="store_true",
                                 default=None, help="Turn zone 1 on.")
     control_parser.add_argument("--off", dest="zone1_power", action="store_false",

--- a/msmart/cli.py
+++ b/msmart/cli.py
@@ -6,7 +6,7 @@ from typing import NoReturn
 from msmart import __version__
 from msmart.cloud import Cloud, CloudError
 from msmart.const import OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD
-from msmart.device import AirConditioner as AC
+from msmart.device import AirConditioner as AC, HeatPump
 from msmart.discover import Discover
 from msmart.lan import AuthenticationError
 
@@ -65,11 +65,11 @@ async def _query(args) -> None:
                 _LOGGER.error("Authentication failed. Error: %s", e)
                 exit(1)
 
-    if not isinstance(device, AC):
-        _LOGGER.error("Device is not supported.")
-        exit(1)
-
     if args.capabilities:
+        if not isinstance(device, AC):
+            _LOGGER.error("Capabilities query is only supported for AC devices.")
+            exit(1)
+
         _LOGGER.info("Querying device capabilities.")
         await device.get_capabilities()
 
@@ -77,7 +77,6 @@ async def _query(args) -> None:
             _LOGGER.error("Device is not online.")
             exit(1)
 
-        # TODO method to get caps in string format
         _LOGGER.info("%s", str({
             "supported_modes": device.supported_operation_modes,
             "supported_swing_modes": device.supported_swing_modes,
@@ -143,6 +142,34 @@ async def _download(args) -> None:
     _LOGGER.info("Writing plugin to '%s'.", plugin_name)
     with open(plugin_name, "wb") as f:
         f.write(plugin_file)
+
+
+async def _control(args) -> None:
+    """Control a heat pump device."""
+
+    _LOGGER.info("Connecting to %s.", args.host)
+    device = await Discover.discover_single(args.host, account=args.account, password=args.password)
+
+    if device is None:
+        _LOGGER.error("Device not found.")
+        exit(1)
+
+    if not isinstance(device, HeatPump):
+        _LOGGER.error("Device at %s is not a heat pump (type=%s).", args.host, hex(device.type))
+        exit(1)
+
+    # Apply requested changes
+    if args.zone1_power is not None:
+        device.zone1.power_state = args.zone1_power
+    if args.temp is not None:
+        device.zone1.target_temperature = args.temp
+    if args.mode is not None:
+        device.run_mode = HeatPump.RunMode[args.mode.upper()]
+
+    _LOGGER.info("Applying: zone1_power=%s, zone1_temp=%s, mode=%s",
+                 device.zone1.power_state, device.zone1.target_temperature, device.run_mode.name)
+    await device.apply()
+    _LOGGER.info("Done.\n%s", device)
 
 
 def _run(args) -> NoReturn:
@@ -234,6 +261,21 @@ def main() -> NoReturn:
                               help="Authentication key for V3 devices.",
                               type=bytes.fromhex)
     query_parser.set_defaults(func=_query)
+
+    # Setup control parser (heat pump)
+    control_parser = subparsers.add_parser("control",
+                                           description="Control a heat pump device.",
+                                           parents=[common_parser])
+    control_parser.add_argument("host", help="Hostname or IP address of device.")
+    control_parser.add_argument("--on", dest="zone1_power", action="store_true",
+                                default=None, help="Turn zone 1 on.")
+    control_parser.add_argument("--off", dest="zone1_power", action="store_false",
+                                help="Turn zone 1 off.")
+    control_parser.add_argument("--temp", type=float, metavar="TEMP",
+                                help="Set zone 1 target temperature (°C).")
+    control_parser.add_argument("--mode", choices=["auto", "heat", "cool", "dhw"],
+                                help="Set run mode.")
+    control_parser.set_defaults(func=_control, zone1_power=None)
 
     # Setup download parser
     download = subparsers.add_parser("download",

--- a/msmart/cloud.py
+++ b/msmart/cloud.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from asyncio import Lock
+from binascii import hexlify, unhexlify
 from datetime import datetime
 from secrets import token_hex, token_urlsafe
 from typing import Any, Dict, Optional, Tuple
@@ -212,6 +213,12 @@ class Cloud:
         self._access_token = response["mdata"]["accessToken"]
         _LOGGER.debug("Received accessToken: %s", self._access_token)
 
+        # Derive relay encryption keys from root-level session fields
+        self._security.set_relay_keys(
+            str(response.get("accessToken", "")),
+            str(response.get("randomData", "")),
+        )
+
     async def get_token(self, udpid: str) -> Tuple[str, str]:
         """Get token and key for the provided udpid."""
 
@@ -261,6 +268,78 @@ class Cloud:
         file_data = self._security.decrypt_aes_app_key(
             encrypted_data).decode("UTF-8")
         return (file_name, file_data)
+
+    def _build_relay_packet(self, device_id: int, cmd_bytes: bytes) -> bytes:
+        """Wrap a device command in the 0x5A5A LAN packet format for cloud relay.
+
+        Cloud relay uses the same packet format as direct LAN communication, but
+        without the local AES encryption layer.
+        """
+        id_bytes = device_id.to_bytes(8, "little")
+        now = datetime.now()
+        pkt = bytearray([
+            0x5A, 0x5A,
+            0x01, 0x11,
+            0x00, 0x00,          # length, filled below
+            0x20, 0x00,
+            0x00, 0x00, 0x00, 0x00,  # message id
+            int(now.microsecond / 10000), now.second, now.minute, now.hour,
+            now.day, now.month, now.year % 100, int(now.year / 100),
+            id_bytes[0], id_bytes[1], id_bytes[2], id_bytes[3],
+            id_bytes[4], id_bytes[5], id_bytes[6], id_bytes[7],
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ])
+        pkt.extend(cmd_bytes)
+        pkt[4:6] = (len(pkt) + 16).to_bytes(2, "little")
+        pkt.extend(self._security.md5_fingerprint(bytes(pkt)))
+        return bytes(pkt)
+
+    async def appliance_transparent_send(self, device_id: int, cmd_bytes: bytes) -> Optional[bytes]:
+        """Send a device command via the cloud relay.
+
+        This bypasses LAN authentication entirely — the cloud server forwards
+        the command over its own authenticated connection to the device.
+
+        Args:
+            device_id: Numeric appliance ID.
+            cmd_bytes: Raw device command frame (0xAA … format).
+
+        Returns:
+            Device response frame (0xAA … format) or None on failure.
+        """
+        if not self._security.has_relay_keys:
+            _LOGGER.error("Cloud relay keys not available; call login() first.")
+            return None
+
+        packet = self._build_relay_packet(device_id, cmd_bytes)
+        order = self._security.encrypt_relay(_Security.encode_as_csv(packet))
+
+        body = self._build_request_body({
+            "order": order,
+            "funId": "0000",
+            "applianceCode": str(device_id),
+        })
+
+        try:
+            response = await self._api_request("/v1/appliance/transparent/send", body)
+        except CloudError as e:
+            _LOGGER.error("Cloud relay request failed: %s", e)
+            return None
+
+        if not response or "reply" not in response:
+            _LOGGER.error("Cloud relay response missing 'reply' field: %s", response)
+            return None
+
+        csv_reply = self._security.decrypt_relay(response["reply"])
+        reply_bytes = _Security.decode_from_csv(csv_reply)
+
+        # Response is a full 0x5A5A packet; strip the 40-byte header
+        if len(reply_bytes) < 40:
+            _LOGGER.error("Cloud relay reply too short (%d bytes).", len(reply_bytes))
+            return None
+
+        return reply_bytes[40:]
 
     async def get_plugin(self, device_type: DeviceType, sn: str) -> Tuple[str, bytes]:
         """Request and download the device plugin."""
@@ -313,8 +392,13 @@ class _Security:
     # MSmartHome
     APP_KEY = "ac21b9f9cbfe4ca5a88562ef25e2b768"
 
+    # Key used to compute MD5 fingerprint on LAN / relay packets
+    RELAY_SIGN_KEY = "xhdiwjnchekd4d512chdjx5d8e4c394D2D7S"
+
     def __init__(self, use_china_server=False):
         self._use_china_server = use_china_server
+        self._relay_data_key: Optional[str] = None
+        self._relay_data_iv: Optional[str] = None
 
     @property
     def _iot_key(self) -> str:
@@ -375,3 +459,53 @@ class _Security:
         key, iv = self._get_app_key_and_iv()
         cipher = AES.new(key, AES.MODE_CBC, iv=iv)
         return Padding.unpad(cipher.decrypt(data), 16)
+
+    def set_relay_keys(self, access_token: str, random_data: str) -> None:
+        """Derive relay encryption keys from the session's root-level accessToken and randomData."""
+        if not access_token or not random_data:
+            return
+        key, iv = self._get_app_key_and_iv()
+        try:
+            cipher1 = AES.new(key, AES.MODE_CBC, iv=iv)
+            self._relay_data_key = Padding.unpad(
+                cipher1.decrypt(unhexlify(access_token)), 16).decode("utf-8")
+            cipher2 = AES.new(key, AES.MODE_CBC, iv=iv)
+            self._relay_data_iv = Padding.unpad(
+                cipher2.decrypt(unhexlify(random_data)), 16).decode("utf-8")
+        except Exception as e:
+            _LOGGER.error("Failed to derive relay keys: %s", e)
+
+    @property
+    def has_relay_keys(self) -> bool:
+        """Return True if relay encryption keys have been derived."""
+        return self._relay_data_key is not None and self._relay_data_iv is not None
+
+    def encrypt_relay(self, data: str) -> str:
+        """AES-CBC encrypt a string with the relay data key, return hex."""
+        assert self._relay_data_key and self._relay_data_iv
+        key = self._relay_data_key.encode("utf-8")
+        iv = self._relay_data_iv.encode("utf-8")
+        cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+        return hexlify(cipher.encrypt(Padding.pad(data.encode("utf-8"), 16))).decode()
+
+    def decrypt_relay(self, hex_data: str) -> str:
+        """AES-CBC decrypt a hex string with the relay data key, return UTF-8 string."""
+        assert self._relay_data_key and self._relay_data_iv
+        key = self._relay_data_key.encode("utf-8")
+        iv = self._relay_data_iv.encode("utf-8")
+        cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+        return Padding.unpad(cipher.decrypt(unhexlify(hex_data)), 16).decode("utf-8")
+
+    def md5_fingerprint(self, data: bytes) -> bytes:
+        """Compute the MD5 packet fingerprint appended to LAN/relay packets."""
+        return hashlib.md5(data + self.RELAY_SIGN_KEY.encode()).digest()
+
+    @staticmethod
+    def encode_as_csv(data: bytes) -> str:
+        """Encode bytes as comma-separated signed integers (relay wire format)."""
+        return ",".join(str(b if b < 128 else b - 256) for b in data)
+
+    @staticmethod
+    def decode_from_csv(data: str) -> bytes:
+        """Decode comma-separated signed integers to bytes."""
+        return bytes(int(x) & 0xFF for x in data.split(","))

--- a/msmart/discover.py
+++ b/msmart/discover.py
@@ -10,7 +10,7 @@ from msmart.cloud import Cloud, CloudError
 from msmart.const import (DEVICE_INFO_MSG, DISCOVERY_MSG,
                           OPEN_MIDEA_APP_ACCOUNT, OPEN_MIDEA_APP_PASSWORD,
                           DeviceType)
-from msmart.device import AirConditioner, Device
+from msmart.device import AirConditioner, Device, HeatPump
 from msmart.lan import AuthenticationError, Security
 
 _LOGGER = logging.getLogger(__name__)
@@ -355,12 +355,20 @@ class Discover:
         if device_type == DeviceType.AIR_CONDITIONER:
             return AirConditioner
 
+        if device_type == DeviceType.HEAT_PUMP:
+            return HeatPump
+
         # Unknown type return generic device
         return Device
 
     @classmethod
     async def _authenticate_device(cls, dev: Device) -> bool:
-        """Attempt to authenticate a V3 device."""
+        """Attempt to authenticate a V3 device.
+
+        First tries LAN authentication using a token fetched from the cloud.
+        If that fails (e.g. getToken returns an error for this device), falls
+        back to cloud relay so the device can still be used.
+        """
 
         # Get cloud connection
         cloud = await Discover._get_cloud()
@@ -378,7 +386,7 @@ class Discover:
             try:
                 token, key = await cloud.get_token(udpid)
             except CloudError as e:
-                _LOGGER.error(e)
+                _LOGGER.debug("Could not get token for udpid '%s': %s", udpid, e)
                 continue
 
             try:
@@ -387,7 +395,11 @@ class Discover:
             except AuthenticationError:
                 continue
 
-        return False
+        # LAN token unavailable — fall back to cloud relay
+        _LOGGER.warning(
+            "LAN authentication failed for device %d; falling back to cloud relay.", dev.id)
+        dev.set_cloud(cloud)
+        return True
 
     @classmethod
     async def _get_device(cls, ip: str, version: int, data: bytes) -> Optional[Device]:


### PR DESCRIPTION
## Problem

C3 heat pumps registered on MSmartHome (`mp-prod.appsmb.com`) consistently return error **3004** from the `getToken` endpoint regardless of udpid format, making LAN V3 authentication impossible. The device is entirely unusable through the library even though it's online and responsive.

This affects at least some users (see #107). The root cause appears to be that MSmartHome's token registry is not populated for C3 devices during WiFi pairing.

## Solution: automatic cloud relay fallback

Midea's cloud API exposes `/v1/appliance/transparent/send` which relays raw device protocol bytes over the cloud's own authenticated connection to the device — bypassing LAN token auth entirely.

When `getToken` fails for all udpid formats, the device is automatically configured to use cloud relay. The `refresh()` and `apply()` interfaces are identical from the caller's perspective; no code changes needed upstream.

## Changes

**`msmart/cloud.py`**
- `Cloud.appliance_transparent_send(device_id, cmd_bytes)`: builds the standard 0x5A5A LAN packet, CSV-encodes it, AES-CBC encrypts with session relay keys, POSTs to `/v1/appliance/transparent/send`, decrypts and returns the device response frame.
- `_Security.set_relay_keys(access_token, random_data)`: derives AES relay keys from the root-level session fields using `SHA256(APP_KEY)` + AES-CBC decrypt. Called automatically after `login()`.
- Helper methods on `_Security`: `encrypt_relay`, `decrypt_relay`, `encode_as_csv`, `decode_from_csv`, `md5_fingerprint`. Note: `RELAY_SIGN_KEY` is the same constant already present in `lan.py` — duplicated here to keep relay crypto self-contained.

**`msmart/base_device.py`**
- `Device.set_cloud(cloud)`: configures the device to route all commands through cloud relay.
- `Device._send_command()`: when `_cloud` is set, calls `appliance_transparent_send` instead of the LAN socket.

**`msmart/discover.py`**
- `_authenticate_device()`: after both LAN auth attempts fail, falls back to `dev.set_cloud(cloud)` and returns `True` so the device remains fully usable.

**`msmart/cli.py`**
- `query`: removed AC-only `isinstance` guard so any discovered device type can be queried.
- `control`: new subcommand for heat pump zone control, with optional `--id` to bypass UDP discovery when the device ID is already known:
  ```
  msmart-ng control <host> --on --temp 35 --mode heat --account <email> --password <pass>
  ```

## Testing

Tested end-to-end against a real KJRH-120F/K (type 0xC3, firmware V3, MSmartHome account) where `getToken` returns 3004:

```python
from msmart.discover import Discover
from msmart.device import HeatPump

device = await Discover.discover_single("192.168.1.2", account=ACCOUNT, password=PASSWORD)
# → WARNING: LAN authentication failed; falling back to cloud relay.

await device.refresh()
# zone1_power=False, zone1_target_temperature=30, mode=HEAT

device.zone1.power_state = True
device.zone1.target_temperature = 35
device.run_mode = HeatPump.RunMode.HEAT
await device.apply()
# zone1_power=True, zone1_target_temperature=35, mode=HEAT ✓
```

All 35 existing unit tests pass. The 3 `test_cloud.py` failures are pre-existing (placeholder credentials that have never worked).

## Trade-offs

- Cloud relay adds one HTTP round-trip (~200–500 ms vs ~50 ms LAN), acceptable for a thermostat.
- Requires internet; pure LAN is unavailable for these devices anyway since token auth is broken.
- Devices where `getToken` works are completely unaffected — relay is only taken as a last resort.