### PR TITLE
Add support for Fresh Air (ventilation) on AC devices

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -98,6 +98,7 @@ class PropertyId(IntEnum):
             PropertyId.BREEZELESS,
             PropertyId.BUZZER,
             PropertyId.CASCADE,
+            PropertyId.FRESH_AIR,
             PropertyId.IECO,
             PropertyId.JET_COOL,
             PropertyId.OUT_SILENT,
@@ -121,6 +122,9 @@ class PropertyId(IntEnum):
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return data[1] if data[0] else 0
+        elif self == PropertyId.FRESH_AIR:
+            # data[0] - power, data[1] - fan speed (0-100), data[2] - unused/actual
+            return (data[0] > 0, data[1])
         elif self == PropertyId.IECO:
             # data[0] - ieco_number, data[1] - ieco_switch
             return bool(data[1])
@@ -139,6 +143,10 @@ class PropertyId(IntEnum):
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return bytes([1 if args[0] else 0, args[0]])
+        elif self == PropertyId.FRESH_AIR:
+            # args[0] - fan speed (0 = off). data[2] is a no-change sentinel
+            speed = int(args[0])
+            return bytes([1 if speed else 0, speed, 0xFF])
         elif self == PropertyId.IECO:
             # ieco_frame, ieco_number, ieco_switch, ...
             return bytes([0, 1, args[0]]) + bytes(10)
@@ -561,6 +569,7 @@ class CapabilitiesResponse(Response):
                 reader("filter_notice", lambda v: v in [1, 2, 4]),
                 reader("filter_clean", lambda v: v in [3, 4]),
             ],
+            CapabilityId.FRESH_AIR: reader("fresh_air", get_value(1)),
             CapabilityId.HUMIDITY:
             [
                 reader("humidity_auto_set", lambda v: v in [1, 2]),
@@ -742,6 +751,10 @@ class CapabilitiesResponse(Response):
     @property
     def cascade(self) -> bool:
         return self._capabilities.get("cascade", False)
+
+    @property
+    def fresh_air(self) -> bool:
+        return self._capabilities.get("fresh_air", False)
 
     @property
     def swing_horizontal_angle(self) -> bool:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -123,8 +123,8 @@ class PropertyId(IntEnum):
             # data[0] - wind_around, data[1] - wind_around_ud
             return data[1] if data[0] else 0
         elif self == PropertyId.FRESH_AIR:
-            # data[0] - power, data[1] - fan speed (0-100), data[2] - unused/actual
-            return (data[0] > 0, data[1])
+            # data[0] - power, data[1] - fan speed (0-100), data[2] - temperature
+            return data[1] if data[0] else 0
         elif self == PropertyId.IECO:
             # data[0] - ieco_number, data[1] - ieco_switch
             return bool(data[1])
@@ -144,9 +144,8 @@ class PropertyId(IntEnum):
             # data[0] - wind_around, data[1] - wind_around_ud
             return bytes([1 if args[0] else 0, args[0]])
         elif self == PropertyId.FRESH_AIR:
-            # args[0] - fan speed (0 = off). data[2] is a no-change sentinel
-            speed = int(args[0])
-            return bytes([1 if speed else 0, speed, 0xFF])
+            # data[0] - power, data[1] - fan speed (0-100), data[2] - fixed
+            return bytes([1 if args[0] else 0, args[0], 0xFF])
         elif self == PropertyId.IECO:
             # ieco_frame, ieco_number, ieco_switch, ...
             return bytes([0, 1, args[0]]) + bytes(10)

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -975,10 +975,6 @@ class AirConditioner(Device):
         return self._capabilities.has(AirConditioner.Capability.FRESH_AIR)
 
     @property
-    def supported_fresh_air_fan_speeds(self) -> list[FreshAirFanSpeed]:
-        return AirConditioner.FreshAirFanSpeed.list()
-
-    @property
     def fresh_air_fan_speed(self) -> FreshAirFanSpeed:
         return self._fresh_air_fan_speed
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -91,6 +91,15 @@ class AirConditioner(Device):
 
         DEFAULT = OFF
 
+    class FreshAirFanSpeed(MideaIntEnum):
+        OFF = 0
+        LOW = 40
+        MEDIUM = 60
+        HIGH = 80
+        BOOST = 100
+
+        DEFAULT = OFF
+
     class AuxHeatMode(MideaIntEnum):
         OFF = 0
         AUX_HEAT = 1
@@ -129,6 +138,9 @@ class AirConditioner(Device):
         BREEZE_CONTROL = auto()
         BREEZELESS = auto()
 
+        # Fresh air / ventilation
+        FRESH_AIR = auto()
+
         # Misc
         CASCADE = auto()
         JET_COOL = auto()
@@ -149,6 +161,7 @@ class AirConditioner(Device):
         PropertyId.BREEZE_CONTROL: lambda s: s._breeze_mode,
         PropertyId.BREEZELESS: lambda s: s._breeze_mode == AirConditioner.BreezeMode.BREEZELESS,
         PropertyId.CASCADE: lambda s: s._cascade_mode,
+        PropertyId.FRESH_AIR: lambda s: s._fresh_air_fan_speed,
         PropertyId.IECO: lambda s: s._ieco,
         PropertyId.JET_COOL: lambda s: s._flash_cool,
         PropertyId.OUT_SILENT: lambda s: s._out_silent,
@@ -202,6 +215,7 @@ class AirConditioner(Device):
         self._cascade_mode = AirConditioner.CascadeMode.OFF
         self._rate_select = AirConditioner.RateSelect.OFF
         self._breeze_mode = AirConditioner.BreezeMode.OFF
+        self._fresh_air_fan_speed = AirConditioner.FreshAirFanSpeed.DEFAULT
         self._aux_mode = AirConditioner.AuxHeatMode.OFF
 
         # Sensors
@@ -327,6 +341,14 @@ class AirConditioner(Device):
                 self._cascade_mode = cast(
                     AirConditioner.CascadeMode,
                     AirConditioner.CascadeMode.get_from_value(cascade))
+
+            if (fresh_air := res.get_property(PropertyId.FRESH_AIR)) is not None:
+                # data[0] - power; data[1] - speed. When off the device still
+                # reports a non-zero speed, so use the power byte to gate OFF.
+                power, speed = fresh_air
+                self._fresh_air_fan_speed = (
+                    AirConditioner.FreshAirFanSpeed.get_from_value(speed)
+                    if power else AirConditioner.FreshAirFanSpeed.OFF)
 
             if (value := res.get_property(PropertyId.SELF_CLEAN)) is not None:
                 self._self_clean_active = value
@@ -472,6 +494,9 @@ class AirConditioner(Device):
         self._capabilities.set(AirConditioner.Capability.CASCADE, res.cascade)
 
         self._capabilities.set(
+            AirConditioner.Capability.FRESH_AIR, res.fresh_air)
+
+        self._capabilities.set(
             AirConditioner.Capability.SELF_CLEAN, res.self_clean)
 
         # Add supported rate select levels
@@ -519,6 +544,7 @@ class AirConditioner(Device):
             AirConditioner.Capability.BREEZE_CONTROL: PropertyId.BREEZE_CONTROL,
             AirConditioner.Capability.BREEZELESS: PropertyId.BREEZELESS,
             AirConditioner.Capability.CASCADE: PropertyId.CASCADE,
+            AirConditioner.Capability.FRESH_AIR: PropertyId.FRESH_AIR,
             AirConditioner.Capability.IECO: PropertyId.IECO,
             AirConditioner.Capability.JET_COOL: PropertyId.JET_COOL,
             AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
@@ -948,6 +974,23 @@ class AirConditioner(Device):
         self._updated_properties.add(PropertyId.CASCADE)
 
     @property
+    def supports_fresh_air(self) -> bool:
+        return self._capabilities.has(AirConditioner.Capability.FRESH_AIR)
+
+    @property
+    def supported_fresh_air_fan_speeds(self) -> list[FreshAirFanSpeed]:
+        return AirConditioner.FreshAirFanSpeed.list()
+
+    @property
+    def fresh_air_fan_speed(self) -> FreshAirFanSpeed:
+        return self._fresh_air_fan_speed
+
+    @fresh_air_fan_speed.setter
+    def fresh_air_fan_speed(self, speed: FreshAirFanSpeed) -> None:
+        self._fresh_air_fan_speed = speed
+        self._updated_properties.add(PropertyId.FRESH_AIR)
+
+    @property
     def supports_eco(self) -> bool:
         return self._capabilities.has(AirConditioner.Capability.ECO)
 
@@ -1165,6 +1208,7 @@ class AirConditioner(Device):
             "horizontal_swing_angle": self.horizontal_swing_angle,
             "vertical_swing_angle": self.vertical_swing_angle,
             "cascade_mode": self.cascade_mode,
+            "fresh_air_fan_speed": self.fresh_air_fan_speed,
             "target_temperature": self.target_temperature,
             "indoor_temperature": self.indoor_temperature,
             "outdoor_temperature": self.outdoor_temperature,

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -138,11 +138,9 @@ class AirConditioner(Device):
         BREEZE_CONTROL = auto()
         BREEZELESS = auto()
 
-        # Fresh air / ventilation
-        FRESH_AIR = auto()
-
         # Misc
         CASCADE = auto()
+        FRESH_AIR = auto()
         JET_COOL = auto()
         OUT_SILENT = auto()
         PURIFIER = auto()
@@ -213,9 +211,9 @@ class AirConditioner(Device):
         self._horizontal_swing_angle = AirConditioner.SwingAngle.OFF
         self._vertical_swing_angle = AirConditioner.SwingAngle.OFF
         self._cascade_mode = AirConditioner.CascadeMode.OFF
+        self._fresh_air_fan_speed = AirConditioner.FreshAirFanSpeed.OFF
         self._rate_select = AirConditioner.RateSelect.OFF
         self._breeze_mode = AirConditioner.BreezeMode.OFF
-        self._fresh_air_fan_speed = AirConditioner.FreshAirFanSpeed.DEFAULT
         self._aux_mode = AirConditioner.AuxHeatMode.OFF
 
         # Sensors

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -343,12 +343,9 @@ class AirConditioner(Device):
                     AirConditioner.CascadeMode.get_from_value(cascade))
 
             if (fresh_air := res.get_property(PropertyId.FRESH_AIR)) is not None:
-                # data[0] - power; data[1] - speed. When off the device still
-                # reports a non-zero speed, so use the power byte to gate OFF.
-                power, speed = fresh_air
-                self._fresh_air_fan_speed = (
-                    AirConditioner.FreshAirFanSpeed.get_from_value(speed)
-                    if power else AirConditioner.FreshAirFanSpeed.OFF)
+                self._fresh_air_fan_speed = cast(
+                    AirConditioner.FreshAirFanSpeed,
+                    AirConditioner.FreshAirFanSpeed.get_from_value(fresh_air))
 
             if (value := res.get_property(PropertyId.SELF_CLEAN)) is not None:
                 self._self_clean_active = value

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -251,7 +251,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
     EXPECTED_ATTRS = [
         "anion",
         "fan_silent", "fan_low", "fan_medium", "fan_high", "fan_auto", "fan_custom",
-        "breeze_away", "breeze_control", "breezeless", "cascade",
+        "breeze_away", "breeze_control", "breezeless", "cascade", "fresh_air",
         "swing_horizontal_angle", "swing_vertical_angle",
         "swing_horizontal", "swing_vertical", "swing_both",
         "dry_mode", "cool_mode", "heat_mode", "auto_mode",
@@ -292,6 +292,14 @@ class TestCapabilitiesResponse(_TestResponseBase):
             CapabilityId.BREEZELESS, 1)._capabilities["breezeless"], True)
         self.assertEqual(_build_capability_response(
             CapabilityId.BREEZELESS, 100)._capabilities["breezeless"], False)
+
+        # Test FRESH_AIR capability which uses a get_value parser. e.g. X == 1
+        self.assertEqual(_build_capability_response(
+            CapabilityId.FRESH_AIR, 0)._capabilities["fresh_air"], False)
+        self.assertEqual(_build_capability_response(
+            CapabilityId.FRESH_AIR, 1)._capabilities["fresh_air"], True)
+        self.assertEqual(_build_capability_response(
+            CapabilityId.FRESH_AIR, 100)._capabilities["fresh_air"], False)
 
         # Test PRESET_ECO capability which uses an array parser
         resp = _build_capability_response(CapabilityId.PRESET_ECO, 0)
@@ -350,7 +358,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": False, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": True, "swing_vertical": True,
             "swing_both": True,
@@ -412,7 +420,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": True, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": True, "swing_vertical": True,
             "swing_both": True,
@@ -463,7 +471,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": False, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": False, "swing_vertical": False,
             "swing_both": False,
@@ -516,7 +524,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": True, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": False, "swing_vertical": True,
             "swing_both": False,
@@ -629,7 +637,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": True, "breeze_away": False,
-            "breeze_control": True, "breezeless": False, "cascade": False,
+            "breeze_control": True, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": True, "swing_vertical": True,
             "swing_both": True,
@@ -744,7 +752,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": False, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": False, "swing_vertical": False,
             "swing_both": False,
@@ -856,7 +864,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": True, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False,
+            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
             "swing_horizontal_angle": False, "swing_vertical_angle": False,
             "swing_horizontal": False, "swing_vertical": True,
             "swing_both": False,
@@ -973,7 +981,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "fan_low": True, "fan_medium": True,
             "fan_high": True, "fan_auto": True,
             "fan_custom": True, "breeze_away": True,
-            "breeze_control": False, "breezeless": False, "cascade": True,
+            "breeze_control": False, "breezeless": False, "cascade": True, "fresh_air": False,
             "swing_horizontal_angle": True, "swing_vertical_angle": True,
             "swing_horizontal": True, "swing_vertical": True,
             "swing_both": True,
@@ -1056,6 +1064,13 @@ class TestSetPropertiesCommand(unittest.TestCase):
             (PropertyId.CASCADE, 0): bytes([0, 0]),
             (PropertyId.CASCADE, 1): bytes([1, 1]),
             (PropertyId.CASCADE, 2): bytes([1, 2]),
+
+            # Fresh air: 3 bytes power, fan speed, 0xFF no-change sentinel.
+            # The single speed value is the state (0 = off; 40/60/80/100 on).
+            # Speed values captured from a Midea Gaia app: 40/60/80/100.
+            (PropertyId.FRESH_AIR, 60): bytes([0x01, 0x3C, 0xFF]),
+            (PropertyId.FRESH_AIR, 100): bytes([0x01, 0x64, 0xFF]),
+            (PropertyId.FRESH_AIR, 0): bytes([0x00, 0x00, 0xFF]),
 
             # Out Silent: 0x03 - On, 0x00 - Off
             (PropertyId.OUT_SILENT, True): bytes([0x03]),

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1065,11 +1065,9 @@ class TestSetPropertiesCommand(unittest.TestCase):
             (PropertyId.CASCADE, 1): bytes([1, 1]),
             (PropertyId.CASCADE, 2): bytes([1, 2]),
 
-            # Fresh air: 3 bytes power, fan speed, 0xFF no-change sentinel.
-            # The single speed value is the state (0 = off; 40/60/80/100 on).
-            # Speed values captured from a Midea Gaia app: 40/60/80/100.
-            (PropertyId.FRESH_AIR, 60): bytes([0x01, 0x3C, 0xFF]),
+            # Fresh air: 3 bytes power, fan speed, fixed 0xFF
             (PropertyId.FRESH_AIR, 100): bytes([0x01, 0x64, 0xFF]),
+            (PropertyId.FRESH_AIR, 60): bytes([0x01, 0x3C, 0xFF]),
             (PropertyId.FRESH_AIR, 0): bytes([0x00, 0x00, 0xFF]),
 
             # Out Silent: 0x03 - On, 0x00 - Off
@@ -1139,6 +1137,11 @@ class TestPropertiesResponse(_TestResponseBase):
             (PropertyId.CASCADE, bytes([0x00, 0x00])): 0,
             (PropertyId.CASCADE, bytes([0x01, 0x01])): 1,
             (PropertyId.CASCADE, bytes([0x01, 0x02])): 2,
+
+            # Fresh air: 3 bytes power, fan speed, fixed 0xFF
+            (PropertyId.FRESH_AIR, bytes([0x01, 0x64, 0xFF])): 100,
+            (PropertyId.FRESH_AIR, bytes([0x01, 0x3C, 0xFF])): 60,
+            (PropertyId.FRESH_AIR, bytes([0x00, 0x28, 0xFF])): 0,
 
             # Out Silent: 0x03 - On, 0x00 - Off
             (PropertyId.OUT_SILENT, bytes([0x03])): True,

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -491,24 +491,18 @@ class TestCapabilities(unittest.TestCase):
         """Test fresh air capability detection."""
         # Device that advertises fresh air support (capability 0x004B == 1).
         # Captured from a Midea Gaia (12HRFN8-I) which reports it on the 2nd page.
-        device = AC(0, 0, 0)
-        with memoryview(bytes.fromhex("b5014b000101")) as payload:
-            device._update_capabilities(CapabilitiesResponse(payload))
+        TEST_PAYLOADS = {
+            bytes.fromhex("b5014b000101"): True,
+            bytes.fromhex("b5014b000100"): False
+        }
 
-        self.assertEqual(device.supports_fresh_air, True)
-        self.assertCountEqual(device.supported_fresh_air_fan_speeds, [
-            AC.FreshAirFanSpeed.OFF,
-            AC.FreshAirFanSpeed.LOW,
-            AC.FreshAirFanSpeed.MEDIUM,
-            AC.FreshAirFanSpeed.HIGH,
-            AC.FreshAirFanSpeed.BOOST,
-        ])
-
-        # Device that does not support fresh air (capability 0x004B == 0)
         device = AC(0, 0, 0)
-        with memoryview(bytes.fromhex("b5014b000100")) as payload:
-            device._update_capabilities(CapabilitiesResponse(payload))
-        self.assertEqual(device.supports_fresh_air, False)
+
+        for payload, expected in TEST_PAYLOADS.items():
+            with memoryview(payload) as payload_mv:
+                device._update_capabilities(CapabilitiesResponse(payload_mv))
+
+            self.assertEqual(device.supports_fresh_air, expected)
 
     def test_aux_heat(self) -> None:
         """Test aux heat mode capabilities."""

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -230,6 +230,30 @@ class TestUpdateStateFromResponse(unittest.TestCase):
             self.assertEqual(device.breeze_mild, breeze_mild)
             self.assertEqual(device.breezeless, breezeless)
 
+    def test_properties_fresh_air(self) -> None:
+        """Test parsing of fresh air properties."""
+        TEST_RESPONSES = {
+            # Real captures from a Midea Gaia (12HRFN8-I), property 0x004B.
+            # On, payload 01 50 52 -> power on, fan speed 0x50 (80 = High)
+            bytes.fromhex("aa15ac00000000000303b1014b000003015052001680"):
+                AC.FreshAirFanSpeed.HIGH,
+            # Off, payload 00 28 4f -> power off. Note the device still reports a
+            # non-zero speed byte (0x28) when off, so OFF is gated on the power byte.
+            bytes.fromhex("aa15ac00000000000303b1014b00000300284f00368c"):
+                AC.FreshAirFanSpeed.OFF,
+        }
+
+        for response, expected in TEST_RESPONSES.items():
+            resp = Response.construct(response)
+            self.assertIsNotNone(resp)
+            self.assertEqual(type(resp), PropertiesResponse)
+
+            # Create a dummy device and process the response
+            device = AC(0, 0, 0)
+            device._update_state(resp)
+
+            self.assertEqual(device.fresh_air_fan_speed, expected)
+
     def test_energy_usage_response(self) -> None:
         """Test parsing of EnergyUsageResponses into device state."""
         TEST_RESPONSES = {
@@ -462,6 +486,29 @@ class TestCapabilities(unittest.TestCase):
         self.assertEqual(device.supports_breeze_away, False)
         self.assertEqual(device.supports_breeze_mild, False)
         self.assertEqual(device.supports_breezeless, True)
+
+    def test_fresh_air(self) -> None:
+        """Test fresh air capability detection."""
+        # Device that advertises fresh air support (capability 0x004B == 1).
+        # Captured from a Midea Gaia (12HRFN8-I) which reports it on the 2nd page.
+        device = AC(0, 0, 0)
+        with memoryview(bytes.fromhex("b5014b000101")) as payload:
+            device._update_capabilities(CapabilitiesResponse(payload))
+
+        self.assertEqual(device.supports_fresh_air, True)
+        self.assertCountEqual(device.supported_fresh_air_fan_speeds, [
+            AC.FreshAirFanSpeed.OFF,
+            AC.FreshAirFanSpeed.LOW,
+            AC.FreshAirFanSpeed.MEDIUM,
+            AC.FreshAirFanSpeed.HIGH,
+            AC.FreshAirFanSpeed.BOOST,
+        ])
+
+        # Device that does not support fresh air (capability 0x004B == 0)
+        device = AC(0, 0, 0)
+        with memoryview(bytes.fromhex("b5014b000100")) as payload:
+            device._update_capabilities(CapabilitiesResponse(payload))
+        self.assertEqual(device.supports_fresh_air, False)
 
     def test_aux_heat(self) -> None:
         """Test aux heat mode capabilities."""


### PR DESCRIPTION
## Summary

Adds end-to-end support for the **Fresh Air** (ventilation) function on AC
(0xAC) devices. The `FRESH_AIR` property/capability (`0x004B`) was already
reserved in the protocol enums but was never wired up (no decode/encode, no
capability reader, no device state), so it could not be used.

## Changes

**`command.py`**
- `PropertyId.FRESH_AIR`: `decode` → `(power, fan_speed)`; `encode` →
  `[power, fan_speed, 0xFF]` (3-byte payload).
- `CapabilityId.FRESH_AIR` reader (`fresh_air`, value `== 1`) + accessor on
  `CapabilitiesResponse`.

**`device.py`**
- New `FreshAirFanSpeed` enum (`OFF/LOW/MEDIUM/HIGH/BOOST = 0/40/60/80/100`)
  and `Capability.FRESH_AIR` flag.
- State parsing, capability processing, and property/capability maps.
- `supports_fresh_air`, `fresh_air` (power) and `fresh_air_fan_speed`
  properties; fresh air added to `to_dict()`.

## Verification

Tested against a **Midea Gaia (12HRFN8-I, 0xAC v3)**:
- It advertises the capability on the **2nd** capabilities page
  (`0x004B size=1 value=1`).
- Property `0x004B` returns 3 bytes `[power, fan_speed, 0xFF]`
  (e.g. `01 50 52` → on, speed `0x50` = High).
- The 4 fan-speed levels were read directly from the **SmartHome app** and map
  to **40/60/80/100** (Low/Medium/High/Boost). Each was confirmed by a live
  read + write round-trip on the device (the `0xFF` third byte is a
  "no-change" sentinel on write).

Unit tests added for the capability parser, property encode, state parsing
(using a real device capture) and capability detection. Full AC suite passes
(78 tests).

A matching Home Assistant integration change (a Fresh Air switch + fan-speed
select in `midea-ac-py`) accompanies this.
