### PR TITLE
Replace "Jet Cool" with "Flash"

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -758,6 +758,10 @@ class CapabilitiesResponse(Response):
         return self._capabilities.get("cascade", False)
 
     @property
+    def flash(self) -> bool:
+        return self._capabilities.get("flash", False)
+
+    @property
     def fresh_air(self) -> bool:
         return self._capabilities.get("fresh_air", False)
 
@@ -817,10 +821,6 @@ class CapabilitiesResponse(Response):
     @property
     def ieco(self) -> bool:
         return self._capabilities.get("ieco", False)
-
-    @property
-    def flash(self) -> bool:
-        return self._capabilities.get("flash", False)
 
     @property
     def turbo(self) -> bool:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -42,7 +42,7 @@ class CapabilityId(IntEnum):
     PARENT_CONTROL = 0x0051  # ??
     PREVENT_STRAIGHT_WIND_SELECT = 0x0058  # ??
     CASCADE = 0x0059  # AKA "Wind Around"
-    JET_COOL = 0x0067  # ??
+    FLASH = 0x0067  # AKA "Jet Cool"
     ICHECK = 0x0091  # ??
     AUX_FAN_SPEED_CONTROL = 0x0093  # AKA "Emergent Heat Wind"
     AUX_HEAT_FAN_SPEED_CONTROL = 0x0094  # AKA "Heat Ptc Wind"
@@ -84,7 +84,7 @@ class PropertyId(IntEnum):
     RATE_SELECT = 0x0048
     FRESH_AIR = 0x004B
     CASCADE = 0x0059  # AKA "Wind Around"
-    JET_COOL = 0x0067  # AKA "Flash Cool"
+    FLASH = 0x0067  # AKA "Jet Cool"
     OUT_SILENT = 0x00CD  # Portasplit outdoor silent mode
     IECO = 0x00E3
     ANION = 0x021E
@@ -100,7 +100,7 @@ class PropertyId(IntEnum):
             PropertyId.CASCADE,
             PropertyId.FRESH_AIR,
             PropertyId.IECO,
-            PropertyId.JET_COOL,
+            PropertyId.FLASH,
             PropertyId.OUT_SILENT,
             PropertyId.RATE_SELECT,
             PropertyId.SELF_CLEAN,
@@ -113,7 +113,7 @@ class PropertyId(IntEnum):
         if not self._supported:
             raise NotImplementedError(f"{repr(self)} decode is not supported.")
 
-        if self in [PropertyId.BREEZELESS, PropertyId.JET_COOL, PropertyId.SELF_CLEAN]:
+        if self in [PropertyId.BREEZELESS, PropertyId.FLASH, PropertyId.SELF_CLEAN]:
             return bool(data[0])
         elif self == PropertyId.BREEZE_AWAY:
             return data[0] == 2
@@ -576,7 +576,7 @@ class CapabilitiesResponse(Response):
                 reader("humidity_auto_set", lambda v: v in [1, 2]),
                 reader("humidity_manual_set", lambda v: v in [2, 3]),
             ],
-            CapabilityId.JET_COOL: reader("jet_cool", get_value(1)),
+            CapabilityId.FLASH: reader("flash", lambda v: v in [1, 2, 3, 4]),
             CapabilityId.MODES: [
                 reader("heat_mode", lambda v:
                        v in [1, 2, 4, 6, 7, 9, 10, 11, 12, 13]),
@@ -819,8 +819,8 @@ class CapabilitiesResponse(Response):
         return self._capabilities.get("ieco", False)
 
     @property
-    def jet_cool(self) -> bool:
-        return self._capabilities.get("jet_cool", False)
+    def flash(self) -> bool:
+        return self._capabilities.get("flash", False)
 
     @property
     def turbo(self) -> bool:

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -98,9 +98,9 @@ class PropertyId(IntEnum):
             PropertyId.BREEZELESS,
             PropertyId.BUZZER,
             PropertyId.CASCADE,
+            PropertyId.FLASH,
             PropertyId.FRESH_AIR,
             PropertyId.IECO,
-            PropertyId.FLASH,
             PropertyId.OUT_SILENT,
             PropertyId.RATE_SELECT,
             PropertyId.SELF_CLEAN,
@@ -570,13 +570,13 @@ class CapabilitiesResponse(Response):
                 reader("filter_notice", lambda v: v in [1, 2, 4]),
                 reader("filter_clean", lambda v: v in [3, 4]),
             ],
+            CapabilityId.FLASH: reader("flash", lambda v: v in [1, 2, 3, 4]),
             CapabilityId.FRESH_AIR: reader("fresh_air", get_value(1)),
             CapabilityId.HUMIDITY:
             [
                 reader("humidity_auto_set", lambda v: v in [1, 2]),
                 reader("humidity_manual_set", lambda v: v in [2, 3]),
             ],
-            CapabilityId.FLASH: reader("flash", lambda v: v in [1, 2, 3, 4]),
             CapabilityId.MODES: [
                 reader("heat_mode", lambda v:
                        v in [1, 2, 4, 6, 7, 9, 10, 11, 12, 13]),

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -141,7 +141,7 @@ class AirConditioner(Device):
         # Misc
         CASCADE = auto()
         FRESH_AIR = auto()
-        JET_COOL = auto()
+        FLASH = auto()
         OUT_SILENT = auto()
         PURIFIER = auto()
         SELF_CLEAN = auto()
@@ -161,7 +161,7 @@ class AirConditioner(Device):
         PropertyId.CASCADE: lambda s: s._cascade_mode,
         PropertyId.FRESH_AIR: lambda s: s._fresh_air_fan_speed,
         PropertyId.IECO: lambda s: s._ieco,
-        PropertyId.JET_COOL: lambda s: s._flash_cool,
+        PropertyId.FLASH: lambda s: s._flash,
         PropertyId.OUT_SILENT: lambda s: s._out_silent,
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
@@ -205,7 +205,7 @@ class AirConditioner(Device):
         self._follow_me = False
         self._purifier = False
         self._ieco = False
-        self._flash_cool = False
+        self._flash = False
         self._out_silent = False
 
         self._horizontal_swing_angle = AirConditioner.SwingAngle.OFF
@@ -369,8 +369,8 @@ class AirConditioner(Device):
             if (value := res.get_property(PropertyId.IECO)) is not None:
                 self._ieco = value
 
-            if (value := res.get_property(PropertyId.JET_COOL)) is not None:
-                self._flash_cool = value
+            if (value := res.get_property(PropertyId.FLASH)) is not None:
+                self._flash = value
 
             if (value := res.get_property(PropertyId.OUT_SILENT)) is not None:
                 self._out_silent = value
@@ -522,8 +522,7 @@ class AirConditioner(Device):
                 AirConditioner.Capability.BREEZELESS, res.breezeless)
 
         self._capabilities.set(AirConditioner.Capability.IECO, res.ieco)
-        self._capabilities.set(
-            AirConditioner.Capability.JET_COOL, res.jet_cool)
+        self._capabilities.set(AirConditioner.Capability.FLASH, res.flash)
 
         self._capabilities.set(
             AirConditioner.Capability.OUT_SILENT, res.out_silent)
@@ -541,7 +540,7 @@ class AirConditioner(Device):
             AirConditioner.Capability.CASCADE: PropertyId.CASCADE,
             AirConditioner.Capability.FRESH_AIR: PropertyId.FRESH_AIR,
             AirConditioner.Capability.IECO: PropertyId.IECO,
-            AirConditioner.Capability.JET_COOL: PropertyId.JET_COOL,
+            AirConditioner.Capability.FLASH: PropertyId.FLASH,
             AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
             AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
             AirConditioner.Capability.SWING_HORIZONTAL_ANGLE: PropertyId.SWING_LR_ANGLE,
@@ -1007,17 +1006,17 @@ class AirConditioner(Device):
         self._updated_properties.add(PropertyId.IECO)
 
     @property
-    def supports_flash_cool(self) -> bool:
-        return self._capabilities.has(AirConditioner.Capability.JET_COOL)
+    def supports_flash(self) -> bool:
+        return self._capabilities.has(AirConditioner.Capability.FLASH)
 
     @property
-    def flash_cool(self) -> Optional[bool]:
-        return self._flash_cool
+    def flash(self) -> Optional[bool]:
+        return self._flash
 
-    @flash_cool.setter
-    def flash_cool(self, enabled: bool) -> None:
-        self._flash_cool = enabled
-        self._updated_properties.add(PropertyId.JET_COOL)
+    @flash.setter
+    def flash(self, enabled: bool) -> None:
+        self._flash = enabled
+        self._updated_properties.add(PropertyId.FLASH)
 
     @property
     def supports_turbo(self) -> bool:
@@ -1321,3 +1320,18 @@ class AirConditioner(Device):
     def real_time_power_usage(self) -> Optional[float]:
         format = AirConditioner.EnergyDataFormat.BINARY if self._use_binary_energy else AirConditioner.EnergyDataFormat.BCD
         return self._real_time_power_usage[format]
+
+    @property
+    @deprecated("supports_flash")
+    def supports_flash_cool(self) -> bool:
+        return self.supports_flash
+
+    @property
+    @deprecated("flash")
+    def flash_cool(self) -> Optional[bool]:
+        return self.flash
+
+    @flash_cool.setter
+    @deprecated("flash")
+    def flash_cool(self, enabled: bool) -> None:
+        self.flash = enabled

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -140,8 +140,8 @@ class AirConditioner(Device):
 
         # Misc
         CASCADE = auto()
-        FRESH_AIR = auto()
         FLASH = auto()
+        FRESH_AIR = auto()
         OUT_SILENT = auto()
         PURIFIER = auto()
         SELF_CLEAN = auto()
@@ -159,9 +159,9 @@ class AirConditioner(Device):
         PropertyId.BREEZE_CONTROL: lambda s: s._breeze_mode,
         PropertyId.BREEZELESS: lambda s: s._breeze_mode == AirConditioner.BreezeMode.BREEZELESS,
         PropertyId.CASCADE: lambda s: s._cascade_mode,
+        PropertyId.FLASH: lambda s: s._flash,
         PropertyId.FRESH_AIR: lambda s: s._fresh_air_fan_speed,
         PropertyId.IECO: lambda s: s._ieco,
-        PropertyId.FLASH: lambda s: s._flash,
         PropertyId.OUT_SILENT: lambda s: s._out_silent,
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
@@ -340,6 +340,9 @@ class AirConditioner(Device):
                     AirConditioner.CascadeMode,
                     AirConditioner.CascadeMode.get_from_value(cascade))
 
+            if (value := res.get_property(PropertyId.FLASH)) is not None:
+                self._flash = value
+
             if (fresh_air := res.get_property(PropertyId.FRESH_AIR)) is not None:
                 self._fresh_air_fan_speed = cast(
                     AirConditioner.FreshAirFanSpeed,
@@ -368,9 +371,6 @@ class AirConditioner(Device):
 
             if (value := res.get_property(PropertyId.IECO)) is not None:
                 self._ieco = value
-
-            if (value := res.get_property(PropertyId.FLASH)) is not None:
-                self._flash = value
 
             if (value := res.get_property(PropertyId.OUT_SILENT)) is not None:
                 self._out_silent = value
@@ -488,6 +488,8 @@ class AirConditioner(Device):
 
         self._capabilities.set(AirConditioner.Capability.CASCADE, res.cascade)
 
+        self._capabilities.set(AirConditioner.Capability.FLASH, res.flash)
+
         self._capabilities.set(
             AirConditioner.Capability.FRESH_AIR, res.fresh_air)
 
@@ -522,7 +524,6 @@ class AirConditioner(Device):
                 AirConditioner.Capability.BREEZELESS, res.breezeless)
 
         self._capabilities.set(AirConditioner.Capability.IECO, res.ieco)
-        self._capabilities.set(AirConditioner.Capability.FLASH, res.flash)
 
         self._capabilities.set(
             AirConditioner.Capability.OUT_SILENT, res.out_silent)
@@ -538,9 +539,9 @@ class AirConditioner(Device):
             AirConditioner.Capability.BREEZE_CONTROL: PropertyId.BREEZE_CONTROL,
             AirConditioner.Capability.BREEZELESS: PropertyId.BREEZELESS,
             AirConditioner.Capability.CASCADE: PropertyId.CASCADE,
+            AirConditioner.Capability.FLASH: PropertyId.FLASH,
             AirConditioner.Capability.FRESH_AIR: PropertyId.FRESH_AIR,
             AirConditioner.Capability.IECO: PropertyId.IECO,
-            AirConditioner.Capability.FLASH: PropertyId.FLASH,
             AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
             AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
             AirConditioner.Capability.SWING_HORIZONTAL_ANGLE: PropertyId.SWING_LR_ANGLE,

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -766,118 +766,28 @@ class TestCapabilitiesResponse(_TestResponseBase):
             self.assertEqual(getattr(resp, prop),
                              EXPECTED_CAPABILITIES[prop], prop)
 
-    def test_capabilities_jet_cool(self) -> None:
-        """Test that we decode capabilities that include jet cool support."""
+    def test_capabilities_flash(self) -> None:
+        """Test that we decode capabilities that include flash support."""
         self.maxDiff = None
 
-        # https://github.com/mill1000/midea-ac-py/issues/343#issuecomment-2864149742
-        TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa39ac00000000000303b5091202010214020100150201001e020100170201021a02010210020101250207203c203c203c002402010101019b9a")
+        TEST_RESPONSES = [
+            # https://github.com/mill1000/midea-ac-py/issues/343#issuecomment-2864149742
+            bytes.fromhex(
+                "aa27ac00000000000303b5051f0201002c020101670001011602010451000101e30001010004f564"),
+            # https://github.com/mill1000/midea-ac-py/issues/425#issuecomment-4744546069
+            bytes.fromhex("aa56ac00000000000803b51012020100180001001402010115020101160201041a020101100201011f020103250207203c203c203c0551000101e30002080867000102c200010098000101950001019d00010101008b43"),
+            #   https://github.com/mill1000/midea-ac-py/issues/426#issue-4693037160
+            bytes.fromhex("aa52ac00000000000803b50f120201001402010015020101160201041a02010110020101250207203c203c203c002402010151000101e3000208086700010495000101980001017c000100cd0001000100bd47"),
+        ]
 
-        resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
-        resp = cast(CapabilitiesResponse, resp)
-
-        EXPECTED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': False,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'swing_horizontal': False,
-            'swing_vertical': True, 'anion': False,
-            'filter_notice': True, 'filter_clean': False,
-            'turbo_heat': False, 'turbo_cool': False,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': False, 'display_control': True
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_RAW_CAPABILITIES)
-
-        # Check if there are additional capabilities
-        self.assertEqual(resp.additional_capabilities, True)
-
-        # Additional capabilities response
-        TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa27ac00000000000303b5051f0201002c020101670001011602010451000101e30001010004f564")
-
-        # Test case includes an unsupported capability
+        # Test cases include some unsupported capabilities
         with self.assertLogs("msmart", logging.DEBUG) as log:
-            additional_resp = self._test_build_response(
-                TEST_ADDITIONAL_CAPABILITIES_RESPONSE)
-            additional_resp = cast(CapabilitiesResponse, additional_resp)
+            for response in TEST_RESPONSES:
+                resp = self._test_build_response(response)
+                resp = cast(CapabilitiesResponse, resp)
 
-            # Check debug message is generated for some unsupported capabilities
-            self.assertRegex("\n".join(log.output),
-                             "Unsupported capability <CapabilityId.PARENT_CONTROL: 81>, Size: 1.")
-
-        EXPECTED_ADDITIONAL_RAW_CAPABILITIES = {
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'jet_cool': True,
-            'buzzer': True, 'energy_stats': True,
-            'energy_setting': False, 'energy_bcd': False,
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(additional_resp._capabilities,
-                         EXPECTED_ADDITIONAL_RAW_CAPABILITIES)
-
-        # Ensure the additional capabilities response doesn't also want more capabilities
-        self.assertEqual(additional_resp.additional_capabilities, False)
-
-        # Check that merging the capabilities produced expected results
-        resp.merge(additional_resp)
-
-        EXPECTED_MERGED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': False,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'swing_horizontal': False,
-            'swing_vertical': True, 'anion': False,
-            'filter_notice': True, 'filter_clean': False,
-            'turbo_heat': False, 'turbo_cool': False,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': False, 'display_control': True,
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'jet_cool': True,
-            'buzzer': True, 'energy_stats': True,
-            'energy_setting': False, 'energy_bcd': False
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
-
-        EXPECTED_CAPABILITIES = {
-            "anion": False, "fan_silent": True,
-            "fan_low": True, "fan_medium": True,
-            "fan_high": True, "fan_auto": True,
-            "fan_custom": True, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
-            "swing_horizontal_angle": False, "swing_vertical_angle": False,
-            "swing_horizontal": False, "swing_vertical": True,
-            "swing_both": False,
-            "dry_mode": True, "cool_mode": True,
-            "heat_mode": False, "auto_mode": True,
-            "aux_heat_mode": False, "aux_mode": False,
-            "aux_electric_heat": False,
-            "eco": True, "ieco": False,
-            "jet_cool": True, "turbo": False,
-            "freeze_protection": False,
-            "display_control": True, "filter_reminder": True,
-            "min_temperature": 16.0, "max_temperature": 30.0,
-            "energy_stats": True, "humidity": False,
-            "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None, "out_silent": False
-        }
-        # Check capabilities properties match
-        for prop in self.EXPECTED_ATTRS:
-            self.assertEqual(getattr(resp, prop),
-                             EXPECTED_CAPABILITIES[prop], prop)
+            self.assertIn("flash", resp._capabilities)
+            self.assertEqual(resp.flash, True)
 
     def test_capabilities_cascade(self) -> None:
         """Test that we decode capabilities that include cascade support."""
@@ -983,7 +893,7 @@ class TestCapabilitiesResponse(_TestResponseBase):
             "aux_heat_mode": False, "aux_mode": False,
             "aux_electric_heat": False,
             "eco": True, "ieco": False,
-            "jet_cool": True, "turbo": True,
+            "flash": True, "turbo": True,
             "freeze_protection": True,
             "display_control": False, "filter_reminder": False,
             "min_temperature": 16.0, "max_temperature": 30.0,

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -615,21 +615,21 @@ class TestSetState(unittest.TestCase):
         self.assertIn(PropertyId.BREEZE_AWAY, device._updated_properties)
         self.assertNotIn(PropertyId.BREEZE_CONTROL, device._updated_properties)
 
-    def test_properties_flash_cool(self) -> None:
-        """Test setting flash/jet cool property."""
+    def test_properties_flash(self) -> None:
+        """Test setting flash cool/heat property."""
 
-        # Create dummy device with jet fool
+        # Create dummy device with flash
         device = AC(0, 0, 0)
-        device._capabilities.set(AC.Capability.JET_COOL)
+        device._capabilities.set(AC.Capability.FLASH)
 
-        # Enable breezeless
-        device.flash_cool = True
+        # Enable flash cool/heat
+        device.flash = True
 
         # Assert state is expected
-        self.assertEqual(device.flash_cool, True)
+        self.assertEqual(device.flash, True)
 
         # Assert correct property is being updated
-        self.assertIn(PropertyId.JET_COOL, device._updated_properties)
+        self.assertIn(PropertyId.FLASH, device._updated_properties)
 
     def test_properties_cascade(self) -> None:
         """Test setting cascade property."""
@@ -990,6 +990,32 @@ class TestDeprecation(unittest.TestCase):
             self.assertRegex("\n".join(log.output),
                              "'use_alternate_energy_format' is deprecated.")
 
+    def test_deprecated_flash_cool(self) -> None:
+        """Test accessing deprecated flash_cool properties emits a warning."""
+
+        # Create dummy device
+        device = AC(0, 0, 0)
+
+        with self.assertLogs("msmart", logging.DEBUG) as log:
+            supports_flash_cool = device.supports_flash_cool
+
+            self.assertRegex("\n".join(log.output),
+                             "'supports_flash_cool' is deprecated")
+
+        # Getter
+        with self.assertLogs("msmart", logging.DEBUG) as log:
+            flash_cool = device.flash_cool
+
+            self.assertRegex("\n".join(log.output),
+                             "'flash_cool' is deprecated")
+
+        # Setter
+        with self.assertLogs("msmart", logging.DEBUG) as log:
+            device.flash_cool = False
+
+            self.assertRegex("\n".join(log.output),
+                             "'flash_cool' is deprecated")
+
 
 class TestCapabilityOverrides(unittest.TestCase):
     """Test overriding device capabilities via serialized dict."""
@@ -1142,7 +1168,7 @@ class TestCapabilityOverrides(unittest.TestCase):
     def test_supported_properties(self) -> None:
         """Test overriding capabilities updated supported properties as needed."""
         TEST_OVERRIDE = {
-            "additional_capabilities": ["SWING_VERTICAL_ANGLE", "JET_COOL"]
+            "additional_capabilities": ["SWING_VERTICAL_ANGLE", "FLASH"]
         }
 
         # Create dummy device
@@ -1171,21 +1197,21 @@ class TestCapabilityOverrides(unittest.TestCase):
 
         # Assert overrides aren't already supported
         self.assertEqual(device.supports_vertical_swing_angle, False)
-        self.assertEqual(device.supports_flash_cool, False)
+        self.assertEqual(device.supports_flash, False)
 
         self.assertNotIn(PropertyId.SWING_UD_ANGLE,
                          device._supported_properties)
-        self.assertNotIn(PropertyId.JET_COOL, device._supported_properties)
+        self.assertNotIn(PropertyId.FLASH, device._supported_properties)
 
         # Override capabilities
         device.override_capabilities(TEST_OVERRIDE)
 
         # Verify overrides are now supported and in supported properties
         self.assertEqual(device.supports_vertical_swing_angle, True)
-        self.assertEqual(device.supports_flash_cool, True)
+        self.assertEqual(device.supports_flash, True)
 
         self.assertIn(PropertyId.SWING_UD_ANGLE, device._supported_properties)
-        self.assertIn(PropertyId.JET_COOL, device._supported_properties)
+        self.assertIn(PropertyId.FLASH, device._supported_properties)
 
         # Verify overrides removed the original capabilities
         self.assertEqual(device.supports_breeze_away, False)


### PR DESCRIPTION
Jet Cool has been renamed to "Flash" as certain devices support the feature in both cool and heat modes.

This PR properly decodes the Flash (Jet Cool) capability for those devices and removes references to "cool" as part of the feature.