### PR TITLE
Simplify specific capability command unit tests 

### DIFF
--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -675,24 +675,8 @@ class TestCapabilitiesResponse(_TestResponseBase):
             self.assertRegex("\n".join(log.output),
                              "Unsupported capability <CapabilityId.BODY_CHECK: 564>, Size: 1.")
 
-        EXPECTED_RAW_CAPABILITIES = {
-            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True,
-            "aux_heat_mode": True, "aux_mode": True,
-            'swing_horizontal': False, 'swing_vertical': False,
-            'turbo_heat': True, 'turbo_cool': True,
-            'cool_min_temperature': 16.0,
-            'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0,
-            'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0,
-            'heat_max_temperature': 30.0,
-            'decimals': False
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_RAW_CAPABILITIES)
-
-        # Check if there are additional capabilities
-        self.assertEqual(resp.additional_capabilities, True)
+        self.assertIn("aux_mode", resp._capabilities)
+        self.assertIn("aux_heat_mode", resp._capabilities)
 
         # Additional capabilities response
         TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
@@ -702,69 +686,14 @@ class TestCapabilitiesResponse(_TestResponseBase):
             TEST_ADDITIONAL_CAPABILITIES_RESPONSE)
         additional_resp = cast(CapabilitiesResponse, additional_resp)
 
-        EXPECTED_ADDITIONAL_RAW_CAPABILITIES = {
-            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False,
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'smart_eye': False, 'freeze_protection': False,
-            'aux_electric_heat': True, 'self_clean': False,
-            'aux_fan_speed': True, 'aux_heat_fan_speed': True,
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(additional_resp._capabilities,
-                         EXPECTED_ADDITIONAL_RAW_CAPABILITIES)
+        self.assertIn("aux_electric_heat", additional_resp._capabilities)
 
-        # Ensure the additional capabilities response doesn't also want more capabilities
-        self.assertEqual(additional_resp.additional_capabilities, False)
-
-        # Check that merging the capabilities produced expected results
+        # Merge capabilities and check final properties
         resp.merge(additional_resp)
 
-        EXPECTED_MERGED_RAW_CAPABILITIES = {
-            'heat_mode': True, 'cool_mode': True, 'dry_mode': True, 'auto_mode': True,
-            "aux_heat_mode": True, "aux_mode": True,
-            'swing_horizontal': False, 'swing_vertical': False,
-            'turbo_heat': True, 'turbo_cool': True,
-            'cool_min_temperature': 16.0,
-            'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0,
-            'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0,
-            'heat_max_temperature': 30.0,
-            'decimals': False,
-            'fan_silent': False, 'fan_low': True, 'fan_medium': True, 'fan_high': True, 'fan_auto': True, 'fan_custom': False,
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'smart_eye': False, 'freeze_protection': False,
-            'aux_electric_heat': True, 'self_clean': False,
-            'aux_fan_speed': True, 'aux_heat_fan_speed': True,
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
-
-        EXPECTED_CAPABILITIES = {
-            "anion": False, "fan_silent": False,
-            "fan_low": True, "fan_medium": True,
-            "fan_high": True, "fan_auto": True,
-            "fan_custom": False, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
-            "swing_horizontal_angle": False, "swing_vertical_angle": False,
-            "swing_horizontal": False, "swing_vertical": False,
-            "swing_both": False,
-            "dry_mode": True, "cool_mode": True,
-            "heat_mode": True, "auto_mode": True,
-            "aux_heat_mode": True, "aux_mode": True,
-            "aux_electric_heat": True,
-            "eco": False, "ieco": False,
-            "turbo": True, "freeze_protection": False,
-            "display_control": False, "filter_reminder": False,
-            "min_temperature": 16.0, "max_temperature": 30.0,
-            "energy_stats": False, "humidity": False,
-            "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None, "out_silent": False
-        }
-        # Check capabilities properties match
-        for prop in self.EXPECTED_ATTRS:
-            self.assertEqual(getattr(resp, prop),
-                             EXPECTED_CAPABILITIES[prop], prop)
+        self.assertEqual(resp.aux_mode, True)
+        self.assertEqual(resp.aux_heat_mode, True)
+        self.assertEqual(resp.aux_electric_heat, True)
 
     def test_capabilities_jet_cool(self) -> None:
         """Test that we decode capabilities that include jet cool support."""
@@ -772,112 +701,13 @@ class TestCapabilitiesResponse(_TestResponseBase):
 
         # https://github.com/mill1000/midea-ac-py/issues/343#issuecomment-2864149742
         TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa39ac00000000000303b5091202010214020100150201001e020100170201021a02010210020101250207203c203c203c002402010101019b9a")
+            "aa27ac00000000000303b5051f0201002c020101670001011602010451000101e30001010004f564")
 
         resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
         resp = cast(CapabilitiesResponse, resp)
 
-        EXPECTED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': False,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'swing_horizontal': False,
-            'swing_vertical': True, 'anion': False,
-            'filter_notice': True, 'filter_clean': False,
-            'turbo_heat': False, 'turbo_cool': False,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': False, 'display_control': True
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_RAW_CAPABILITIES)
-
-        # Check if there are additional capabilities
-        self.assertEqual(resp.additional_capabilities, True)
-
-        # Additional capabilities response
-        TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa27ac00000000000303b5051f0201002c020101670001011602010451000101e30001010004f564")
-
-        # Test case includes an unsupported capability
-        with self.assertLogs("msmart", logging.DEBUG) as log:
-            additional_resp = self._test_build_response(
-                TEST_ADDITIONAL_CAPABILITIES_RESPONSE)
-            additional_resp = cast(CapabilitiesResponse, additional_resp)
-
-            # Check debug message is generated for some unsupported capabilities
-            self.assertRegex("\n".join(log.output),
-                             "Unsupported capability <CapabilityId.PARENT_CONTROL: 81>, Size: 1.")
-
-        EXPECTED_ADDITIONAL_RAW_CAPABILITIES = {
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'jet_cool': True,
-            'buzzer': True, 'energy_stats': True,
-            'energy_setting': False, 'energy_bcd': False,
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(additional_resp._capabilities,
-                         EXPECTED_ADDITIONAL_RAW_CAPABILITIES)
-
-        # Ensure the additional capabilities response doesn't also want more capabilities
-        self.assertEqual(additional_resp.additional_capabilities, False)
-
-        # Check that merging the capabilities produced expected results
-        resp.merge(additional_resp)
-
-        EXPECTED_MERGED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': False,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'swing_horizontal': False,
-            'swing_vertical': True, 'anion': False,
-            'filter_notice': True, 'filter_clean': False,
-            'turbo_heat': False, 'turbo_cool': False,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': False, 'display_control': True,
-            'humidity_auto_set': False, 'humidity_manual_set': False,
-            'jet_cool': True,
-            'buzzer': True, 'energy_stats': True,
-            'energy_setting': False, 'energy_bcd': False
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
-
-        EXPECTED_CAPABILITIES = {
-            "anion": False, "fan_silent": True,
-            "fan_low": True, "fan_medium": True,
-            "fan_high": True, "fan_auto": True,
-            "fan_custom": True, "breeze_away": False,
-            "breeze_control": False, "breezeless": False, "cascade": False, "fresh_air": False,
-            "swing_horizontal_angle": False, "swing_vertical_angle": False,
-            "swing_horizontal": False, "swing_vertical": True,
-            "swing_both": False,
-            "dry_mode": True, "cool_mode": True,
-            "heat_mode": False, "auto_mode": True,
-            "aux_heat_mode": False, "aux_mode": False,
-            "aux_electric_heat": False,
-            "eco": True, "ieco": False,
-            "jet_cool": True, "turbo": False,
-            "freeze_protection": False,
-            "display_control": True, "filter_reminder": True,
-            "min_temperature": 16.0, "max_temperature": 30.0,
-            "energy_stats": True, "humidity": False,
-            "target_humidity": False, "self_clean": False,
-            "rate_select_levels": None, "out_silent": False
-        }
-        # Check capabilities properties match
-        for prop in self.EXPECTED_ATTRS:
-            self.assertEqual(getattr(resp, prop),
-                             EXPECTED_CAPABILITIES[prop], prop)
+        self.assertIn("jet_cool", resp._capabilities)
+        self.assertEqual(resp.jet_cool, True)
 
     def test_capabilities_cascade(self) -> None:
         """Test that we decode capabilities that include cascade support."""
@@ -885,116 +715,13 @@ class TestCapabilitiesResponse(_TestResponseBase):
 
         # https://github.com/mill1000/midea-ac-py/issues/359#issuecomment-3028509967
         TEST_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa3dac00000000000303b50a12020101430001001402010115020101160201001a020101100201011f020103250207203c203c203c05400001000100e1ed")
+            "aa3bac00000000000303b50a1e02010113020101220201001902010039000101580001024200010159000101090001010a000101000000000000cfbf")
 
         resp = self._test_build_response(TEST_CAPABILITIES_RESPONSE)
         resp = cast(CapabilitiesResponse, resp)
 
-        EXPECTED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': True,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'breeze_control': False,
-            'swing_horizontal': True, 'swing_vertical': True,
-            'turbo_heat': True, 'turbo_cool': True,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'humidity_auto_set': False, 'humidity_manual_set': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': True,
-            'energy_bcd': False, 'energy_setting': False, 'energy_stats': False,
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_RAW_CAPABILITIES)
-
-        # Check if there are additional capabilities
-        self.assertEqual(resp.additional_capabilities, True)
-
-        # Additional capabilities response
-        TEST_ADDITIONAL_CAPABILITIES_RESPONSE = bytes.fromhex(
-            "aa3bac00000000000303b50a1e02010113020101220201001902010039000101580001024200010159000101090001010a000101000000000000cfbf")
-
-        # Test case includes an unsupported capability
-        with self.assertLogs("msmart", logging.DEBUG) as log:
-            additional_resp = self._test_build_response(
-                TEST_ADDITIONAL_CAPABILITIES_RESPONSE)
-            additional_resp = cast(CapabilitiesResponse, additional_resp)
-
-            # Check debug message is generated for some unsupported capabilities
-            self.assertRegex("\n".join(log.output),
-                             "Unsupported capability <CapabilityId.PREVENT_STRAIGHT_WIND_SELECT: 88>, Size: 1.")
-
-        EXPECTED_ADDITIONAL_RAW_CAPABILITIES = {
-            'anion': True, 'aux_electric_heat': False,
-            'breeze_away': True, 'cascade': True,
-            'fahrenheit': True, 'freeze_protection': True, 'self_clean': True,
-            'swing_horizontal_angle': True, 'swing_vertical_angle': True
-        }
-
-        # Ensure raw decoded capabilities match
-        self.assertEqual(additional_resp._capabilities,
-                         EXPECTED_ADDITIONAL_RAW_CAPABILITIES)
-
-        # Ensure the additional capabilities response doesn't also want more capabilities
-        self.assertEqual(additional_resp.additional_capabilities, False)
-
-        # Check that merging the capabilities produced expected results
-        resp.merge(additional_resp)
-
-        EXPECTED_MERGED_RAW_CAPABILITIES = {
-            'eco': True, 'heat_mode': True,
-            'cool_mode': True, 'dry_mode': True,
-            'auto_mode': True, 'aux_heat_mode': False,
-            'aux_mode': False, 'swing_horizontal': True,
-            'swing_vertical': True, 'anion': True,
-            'turbo_heat': True, 'turbo_cool': True,
-            'fan_silent': False, 'fan_low': False,
-            'fan_medium': False, 'fan_high': False,
-            'fan_auto': False, 'fan_custom': True,
-            'cool_min_temperature': 16.0, 'cool_max_temperature': 30.0,
-            'auto_min_temperature': 16.0, 'auto_max_temperature': 30.0,
-            'heat_min_temperature': 16.0, 'heat_max_temperature': 30.0,
-            'decimals': True,
-            'humidity_auto_set': False, 'humidity_manual_set': True,
-            'energy_stats': False, 'energy_setting': False, 'energy_bcd': False,
-            'aux_electric_heat': False,
-            'breeze_control': False,
-            'breeze_away': True, 'cascade': True,
-            'fahrenheit': True, 'freeze_protection': True, 'self_clean': True,
-            'swing_horizontal_angle': True, 'swing_vertical_angle': True
-        }
-        # Ensure raw decoded capabilities match
-        self.assertEqual(resp._capabilities, EXPECTED_MERGED_RAW_CAPABILITIES)
-
-        EXPECTED_CAPABILITIES = {
-            "anion": True, "fan_silent": True,
-            "fan_low": True, "fan_medium": True,
-            "fan_high": True, "fan_auto": True,
-            "fan_custom": True, "breeze_away": True,
-            "breeze_control": False, "breezeless": False, "cascade": True, "fresh_air": False,
-            "swing_horizontal_angle": True, "swing_vertical_angle": True,
-            "swing_horizontal": True, "swing_vertical": True,
-            "swing_both": True,
-            "dry_mode": True, "cool_mode": True,
-            "heat_mode": True, "auto_mode": True,
-            "aux_heat_mode": False, "aux_mode": False,
-            "aux_electric_heat": False,
-            "eco": True, "ieco": False,
-            "jet_cool": True, "turbo": True,
-            "freeze_protection": True,
-            "display_control": False, "filter_reminder": False,
-            "min_temperature": 16.0, "max_temperature": 30.0,
-            "energy_stats": False, "humidity": True,
-            "target_humidity": True, "self_clean": True,
-            "rate_select_levels": None, "out_silent": False
-        }
-        # Check capabilities properties match
-        for prop in self.EXPECTED_ATTRS:
-            self.assertEqual(getattr(resp, prop),
-                             EXPECTED_CAPABILITIES[prop], prop)
+        self.assertIn("cascade", resp._capabilities)
+        self.assertEqual(resp.cascade, True)
 
     def test_capabilities_out_silent(self) -> None:
         """Test that we decode the OUT_SILENT capability correctly from a real PortaSplit payload."""


### PR DESCRIPTION
Tests were overzealously testing the entire capability flow instead of just the specific capability