### PR TITLE
docs: clarify PARENT_CONTROL (0x0051) as Temp Range limits

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -41,7 +41,7 @@ class CapabilityId(IntEnum):
     RATE_SELECT = 0x0048
     FSU_SMART_COOL = 0x0049  # Floor-standing Unit, "Prevent Super Cool"
     FRESH_AIR = 0x004B
-    PARENT_CONTROL = 0x0051  # ??
+    PARENT_CONTROL = 0x0051  # AKA "Temp Range" (Sets software min/max target temperature limits)
     PREVENT_STRAIGHT_WIND_SELECT = 0x0058  # ??
     CASCADE = 0x0059  # AKA "Wind Around"
     FSU_STERILIZE = 0x005A  # Floor-standing Unit


### PR DESCRIPTION
Updates the comment for `PARENT_CONTROL` (`0x0051`) to reflect its actual function: setting the software-enforced min/max target temperature limits.

### Payload Structure
When constructing a New Protocol (`0xB0`) set message, capability `0x0051` expects a 3-byte payload: 
`[Status] [Min Temp] [Max Temp]`

* **Status:** `0x01` (Enabled) or `0x00` (Disabled)
* **Min Temp:** Desired minimum °C * 2 
* **Max Temp:** Desired maximum °C * 2 

**Example:**
To enable the limits and set the range to 20°C - 23°C (`0x28` and `0x2E`):
* Payload bytes: `01 28 2E`
* Appended to B0 message: `51 00 03 01 28 2E`