### PR TITLE
Rename group 1 temperature outputs. Comment out redundant indoor temperature.

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -1144,12 +1144,12 @@ class Group1Response(Response):
         self.compressor_voltage: Optional[int] = None
 
         # Refrigerant circuit temperatures
-        # T1: indoor coil
+        # T1: indoor ambient
+        self.indoor_temperature: Optional[float] = None
+        # T2: indoor coil
         self.indoor_coil_temperature: Optional[float] = None
-        # T2: evaporator outlet
-        self.evaporator_temperature: Optional[float] = None
-        # T3: condenser temperature
-        self.condenser_temperature: Optional[float] = None
+        # T3: outdoor coil
+        self.outdoor_coil_temperature: Optional[float] = None
         # T4: outdoor ambient temperature
         self.outdoor_temperature: Optional[float] = None
         # TP: discharge pipe temperature (compressor outlet)
@@ -1164,10 +1164,10 @@ class Group1Response(Response):
         self.compressor_voltage = payload[8]
 
         # T1/T2 use offset 30: (raw - 30) / 2
-        self.indoor_coil_temperature = (payload[10] - 30) / 2
-        self.evaporator_temperature = (payload[11] - 30) / 2
+        self.indoor_temperature = (payload[10] - 30) / 2
+        self.indoor_coil_temperature = (payload[11] - 30) / 2
         # T3/T4 use offset 50: (raw - 50) / 2
-        self.condenser_temperature = (payload[12] - 50) / 2
+        self.outdoor_coil_temperature = (payload[12] - 50) / 2
         self.outdoor_temperature = (payload[13] - 50) / 2
         # TP: raw temperature in C
         self.discharge_pipe_temperature = payload[14]

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -412,7 +412,7 @@ class AirConditioner(Device):
             self._compressor_frequency = res.compressor_frequency
             self._compressor_current = res.compressor_current
             self._compressor_voltage = res.compressor_voltage
-            #self._indoor_temperature = res.indoor_temperature
+            # self._indoor_temperature = res.indoor_temperature
             self._indoor_coil_temperature = res.indoor_coil_temperature
             self._outdoor_coil_temperature = res.outdoor_coil_temperature
             # self._outdoor_temperature = res.outdoor_temperature

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -250,8 +250,7 @@ class AirConditioner(Device):
         self._compressor_voltage: Optional[int] = None
         # Refrigerant circuit temperatures
         self._indoor_coil_temperature: Optional[float] = None
-        self._evaporator_temperature: Optional[float] = None
-        self._condenser_temperature: Optional[float] = None
+        self._outdoor_coil_temperature: Optional[float] = None
         self._discharge_pipe_temperature: Optional[int] = None
 
         # Group 2 — indoor unit fan data
@@ -413,9 +412,9 @@ class AirConditioner(Device):
             self._compressor_frequency = res.compressor_frequency
             self._compressor_current = res.compressor_current
             self._compressor_voltage = res.compressor_voltage
+            #self._indoor_temperature = res.indoor_temperature
             self._indoor_coil_temperature = res.indoor_coil_temperature
-            self._evaporator_temperature = res.evaporator_temperature
-            self._condenser_temperature = res.condenser_temperature
+            self._outdoor_coil_temperature = res.outdoor_coil_temperature
             # self._outdoor_temperature = res.outdoor_temperature
             self._discharge_pipe_temperature = res.discharge_pipe_temperature
 
@@ -1310,18 +1309,13 @@ class AirConditioner(Device):
 
     @property
     def indoor_coil_temperature(self) -> Optional[float]:
-        """Indoor coil temperature in C — T1 sensor."""
+        """Indoor coil temperature in C — T2 sensor."""
         return self._indoor_coil_temperature
 
     @property
-    def evaporator_temperature(self) -> Optional[float]:
-        """Evaporator temperature in C - T2 sensor."""
-        return self._evaporator_temperature
-
-    @property
-    def condenser_temperature(self) -> Optional[float]:
-        """Condenser temperature in C - T3 sensor."""
-        return self._condenser_temperature
+    def outdoor_coil_temperature(self) -> Optional[float]:
+        """Outdoor coil temperature in C - T3 sensor."""
+        return self._outdoor_coil_temperature
 
     @property
     def discharge_pipe_temperature(self) -> Optional[int]:
@@ -1423,8 +1417,7 @@ class AirConditioner(Device):
             "compressor_current": self.compressor_current,
             "compressor_voltage": self.compressor_voltage,
             "indoor_coil_temperature": self.indoor_coil_temperature,
-            "evaporator_temperature": self.evaporator_temperature,
-            "condenser_temperature": self.condenser_temperature,
+            "outdoor_coil_temperature": self.outdoor_coil_temperature,
             "discharge_pipe_temperature": self.discharge_pipe_temperature,
             # Group 2 — indoor unit fan data
             "target_indoor_fan_speed": self.target_indoor_fan_speed,

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -1199,9 +1199,9 @@ class TestGroupDataResponse(_TestResponseBase):
         self.assertEqual(resp.target_compressor_frequency, 29)
         self.assertEqual(resp.compressor_current, 1)
         self.assertEqual(resp.compressor_voltage, 232)
-        self.assertEqual(resp.indoor_coil_temperature, 20.5)
-        self.assertEqual(resp.evaporator_temperature, 4.0)
-        self.assertEqual(resp.condenser_temperature, 26.0)
+        self.assertEqual(resp.indoor_temperature, 20.5)
+        self.assertEqual(resp.indoor_coil_temperature, 4.0)
+        self.assertEqual(resp.outdoor_coil_temperature, 26.0)
         self.assertEqual(resp.outdoor_temperature, 19.0)
         self.assertEqual(resp.discharge_pipe_temperature, 45)
 

--- a/msmart/device/AC/test_device.py
+++ b/msmart/device/AC/test_device.py
@@ -372,9 +372,9 @@ class TestUpdateStateFromResponse(unittest.TestCase):
         self.assertEqual(device.target_compressor_frequency, 36)
         self.assertEqual(device.compressor_current, 4)
         self.assertEqual(device.compressor_voltage, 230)
-        self.assertEqual(device.indoor_coil_temperature, 21.0)
-        self.assertEqual(device.evaporator_temperature, 8.0)
-        self.assertEqual(device.condenser_temperature, 45.0)
+        # self.assertEqual(device.indoor_temperature, 21.0)
+        self.assertEqual(device.indoor_coil_temperature, 8.0)
+        self.assertEqual(device.outdoor_coil_temperature, 45.0)
         # self.assertEqual(device.outdoor_temperature, 12.0)
         self.assertEqual(device.discharge_pipe_temperature, 55)
 


### PR DESCRIPTION


The property names that were chosen for the group 1 temperatures were poor. From PR https://github.com/mill1000/midea-msmart/pull/278

T1: Indoor ambient temperature (improperly named "indoor_coil_temperature"). Renamed to "indoor_temperature" and commented out due to redundancy with existing output of the same name.
T2: Indoor coil temperature (improperly named "evaporator_temperature"). The indoor coil can be an evaporator in cooling mode or a condenser in heat mode. Renamed to "indoor_coil_temperature".
T3: outdoor coil temperature (improperly named "condenser_temperature"). The outdoor coil can be a condenser in cooling mode or an evaporator in heat mode. Renamed to "outdoor_coil_temperature".
T4: Outdoor ambient temperature. Name is okay. Already commented out due to redundancy with existing output of the same name.

The new names reflect the names used by the manufacturer. See page 6 of https://cematraining.com/wp-content/uploads/2022/03/SG-RG10-01.pdf
