### PR TITLE
Add support for newer SOUND property & capability

### DIFF
--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -118,15 +118,15 @@ class PropertyId(IntEnum):
             PropertyId.BREEZE_AWAY,
             PropertyId.BREEZE_CONTROL,
             PropertyId.BREEZELESS,
-            PropertyId.PROMPT_TONE,
-            PropertyId.SOUND,
             PropertyId.CASCADE,
             PropertyId.FLASH,
             PropertyId.FRESH_AIR,
             PropertyId.IECO,
             PropertyId.OUT_SILENT,
+            PropertyId.PROMPT_TONE,
             PropertyId.RATE_SELECT,
             PropertyId.SELF_CLEAN,
+            PropertyId.SOUND,
             PropertyId.SWING_LR_ANGLE,
             PropertyId.SWING_UD_ANGLE,
         ]
@@ -136,7 +136,7 @@ class PropertyId(IntEnum):
         if not self._supported:
             raise NotImplementedError(f"{repr(self)} decode is not supported.")
 
-        if self in [PropertyId.BREEZELESS, PropertyId.FLASH, PropertyId.SELF_CLEAN, PropertyId.SOUND, PropertyId.PROMPT_TONE]:
+        if self in [PropertyId.BREEZELESS, PropertyId.FLASH, PropertyId.PROMPT_TONE, PropertyId.SELF_CLEAN, PropertyId.SOUND]:
             return bool(data[0])
         elif self == PropertyId.BREEZE_AWAY:
             return data[0] == 2
@@ -161,7 +161,7 @@ class PropertyId(IntEnum):
 
         if self == PropertyId.BREEZE_AWAY:
             return bytes([2 if args[0] else 1])
-        elif self in [PropertyId.SOUND, PropertyId.PROMPT_TONE]:
+        elif self in [PropertyId.PROMPT_TONE, PropertyId.SOUND]:
             return bytes([1 if args[0] else 0])
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -800,6 +800,10 @@ class CapabilitiesResponse(Response):
         return self._capabilities.get("fresh_air", False)
 
     @property
+    def sound(self) -> bool:
+        return self._capabilities.get("sound", False)
+
+    @property
     def swing_horizontal_angle(self) -> bool:
         return self._capabilities.get("swing_horizontal_angle", False)
 

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -85,7 +85,7 @@ class CapabilityId(IntEnum):
     FAHRENHEIT = 0x0222
     DISPLAY_CONTROL = 0x0224
     TEMPERATURES = 0x0225
-    BUZZER = 0x022C  # TODO Reference refers to this as "sound". Is this different then buzzer?
+    SOUND = 0x022C
     MAIN_HORIZONTAL_GUIDE_STRIP = 0x0230  # ??
     SUP_HORIZONTAL_GUIDE_STRIP = 0x0231  # ??
     TWINS_MACHINE = 0x0232  # ??
@@ -98,7 +98,7 @@ class PropertyId(IntEnum):
     SWING_LR_ANGLE = 0x000A
     INDOOR_HUMIDITY = 0x0015  # TODO Reference refers to a potential bug with this
     BREEZELESS = 0x0018  # AKA "No Wind Sense"
-    BUZZER = 0x001A
+    PROMPT_TONE = 0x001A
     SELF_CLEAN = 0x0039
     BREEZE_AWAY = 0x0042  # AKA "Prevent Straight Wind"
     BREEZE_CONTROL = 0x0043  # AKA "FA No Wind Sense"
@@ -109,6 +109,7 @@ class PropertyId(IntEnum):
     OUT_SILENT = 0x00CD  # Portasplit outdoor silent mode
     IECO = 0x00E3
     ANION = 0x021E
+    SOUND = 0x022C
 
     @property
     def _supported(self) -> bool:
@@ -117,7 +118,8 @@ class PropertyId(IntEnum):
             PropertyId.BREEZE_AWAY,
             PropertyId.BREEZE_CONTROL,
             PropertyId.BREEZELESS,
-            PropertyId.BUZZER,
+            PropertyId.PROMPT_TONE,
+            PropertyId.SOUND,
             PropertyId.CASCADE,
             PropertyId.FLASH,
             PropertyId.FRESH_AIR,
@@ -134,12 +136,10 @@ class PropertyId(IntEnum):
         if not self._supported:
             raise NotImplementedError(f"{repr(self)} decode is not supported.")
 
-        if self in [PropertyId.BREEZELESS, PropertyId.FLASH, PropertyId.SELF_CLEAN]:
+        if self in [PropertyId.BREEZELESS, PropertyId.FLASH, PropertyId.SELF_CLEAN, PropertyId.SOUND, PropertyId.PROMPT_TONE]:
             return bool(data[0])
         elif self == PropertyId.BREEZE_AWAY:
             return data[0] == 2
-        elif self == PropertyId.BUZZER:
-            return None  # Don't decode buzzer
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return data[1] if data[0] else 0
@@ -161,6 +161,8 @@ class PropertyId(IntEnum):
 
         if self == PropertyId.BREEZE_AWAY:
             return bytes([2 if args[0] else 1])
+        elif self in [PropertyId.SOUND, PropertyId.PROMPT_TONE]:
+            return bytes([1 if args[0] else 0])
         elif self == PropertyId.CASCADE:
             # data[0] - wind_around, data[1] - wind_around_ud
             return bytes([1 if args[0] else 0, args[0]])
@@ -567,7 +569,7 @@ class CapabilitiesResponse(Response):
             CapabilityId.BREEZE_AWAY: reader("breeze_away", get_value(1)),
             CapabilityId.BREEZE_CONTROL: reader("breeze_control", get_value(1)),
             CapabilityId.BREEZELESS: reader("breezeless", get_value(1)),
-            CapabilityId.BUZZER:  reader("buzzer", get_value(1)),
+            CapabilityId.SOUND:  reader("sound", get_value(1)),
             CapabilityId.CASCADE:  reader("cascade", get_value(1)),
             CapabilityId.DISPLAY_CONTROL: reader("display_control", any_of([1, 2, 100])),
             CapabilityId.ENERGY: [

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -776,8 +776,8 @@ class AirConditioner(Device):
             _LOGGER.warning(
                 "Device %s is not capable of property %r.", self.id, prop)
 
-        # Always add buzzer property
-        properties[PropertyId.BUZZER] = self._beep_on
+        # Always add sound property
+        properties[PropertyId.SOUND] = self._beep_on
 
         # Build command with properties
         cmd = SetPropertiesCommand(properties)

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -146,6 +146,7 @@ class AirConditioner(Device):
         OUT_SILENT = auto()
         PURIFIER = auto()
         SELF_CLEAN = auto()
+        SOUND = auto()
 
         DEFAULT = (
             CUSTOM_FAN_SPEED |
@@ -167,6 +168,8 @@ class AirConditioner(Device):
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
         PropertyId.SWING_UD_ANGLE: lambda s: s._vertical_swing_angle,
+        PropertyId.PROMPT_TONE: lambda s: s._beep_on,
+        PropertyId.SOUND: lambda s: s._sound,
     }
 
     _SUPPORTED_CAPABILITY_OVERRIDES = {
@@ -201,6 +204,7 @@ class AirConditioner(Device):
 
         self._fahrenheit_unit = False  # Display temperature in Fahrenheit
         self._display_on = False
+        self._sound = None
 
         # Advanced controls
         self._follow_me = False
@@ -402,6 +406,9 @@ class AirConditioner(Device):
 
             if (value := res.get_property(PropertyId.OUT_SILENT)) is not None:
                 self._out_silent = value
+
+            if (value := res.get_property(PropertyId.SOUND)) is not None:
+                self._sound = value
 
         elif isinstance(res, Group1Response):
             _LOGGER.debug("Group 1 response payload from device %s: %s",
@@ -609,6 +616,7 @@ class AirConditioner(Device):
             AirConditioner.Capability.IECO: PropertyId.IECO,
             AirConditioner.Capability.OUT_SILENT: PropertyId.OUT_SILENT,
             AirConditioner.Capability.SELF_CLEAN: PropertyId.SELF_CLEAN,
+            AirConditioner.Capability.SOUND: PropertyId.SOUND,
             AirConditioner.Capability.SWING_HORIZONTAL_ANGLE: PropertyId.SWING_LR_ANGLE,
             AirConditioner.Capability.SWING_VERTICAL_ANGLE: PropertyId.SWING_UD_ANGLE,
         }
@@ -624,6 +632,10 @@ class AirConditioner(Device):
         # Rate select is a special case. It's property based but not controlled by a capability flag
         if self._supported_rate_selects != [AirConditioner.RateSelect.OFF]:
             self._supported_properties.add(PropertyId.RATE_SELECT)
+
+        # Always support prompt tone if the device supports any properties
+        if len(self._supported_properties) > 0:
+            self._supported_properties.add(PropertyId.PROMPT_TONE)
 
     async def _send_commands_get_responses(self, commands: Union[Command, list[Command]]) -> list[Response]:
         """Send a list of commands and return all valid responses."""
@@ -776,9 +788,6 @@ class AirConditioner(Device):
             _LOGGER.warning(
                 "Device %s is not capable of property %r.", self.id, prop)
 
-        # Always add sound property
-        properties[PropertyId.SOUND] = self._beep_on
-
         # Build command with properties
         cmd = SetPropertiesCommand(properties)
         for response in await self._send_commands_get_responses(cmd):
@@ -876,6 +885,16 @@ class AirConditioner(Device):
     @beep.setter
     def beep(self, tone: bool) -> None:
         self._beep_on = tone
+        self._updated_properties.add(PropertyId.PROMPT_TONE)
+
+    @property
+    def sound(self) -> Optional[bool]:
+        return self._sound
+
+    @sound.setter
+    def sound(self, enabled: bool) -> None:
+        self._sound = enabled
+        self._updated_properties.add(PropertyId.SOUND)
 
     @property
     def power_state(self) -> Optional[bool]:
@@ -1396,6 +1415,7 @@ class AirConditioner(Device):
             "sleep": self.sleep,
             "display_on": self.display_on,
             "beep": self.beep,
+            "sound": self.sound,
             "fahrenheit": self.fahrenheit,
             "filter_alert": self.filter_alert,
             "follow_me": self.follow_me,

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -600,6 +600,9 @@ class AirConditioner(Device):
         self._capabilities.set(
             AirConditioner.Capability.OUT_SILENT, res.out_silent)
 
+        self._capabilities.set(
+            AirConditioner.Capability.SOUND, res.sound)
+
         # Update supported properties from capabilities
         self._update_supported_properties()
 

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -791,6 +791,9 @@ class AirConditioner(Device):
             _LOGGER.warning(
                 "Device %s is not capable of property %r.", self.id, prop)
 
+        # Always add prompt tone property
+        properties[PropertyId.PROMPT_TONE] = self._beep_on
+
         # Build command with properties
         cmd = SetPropertiesCommand(properties)
         for response in await self._send_commands_get_responses(cmd):

--- a/msmart/device/AC/device.py
+++ b/msmart/device/AC/device.py
@@ -165,11 +165,11 @@ class AirConditioner(Device):
         PropertyId.FRESH_AIR: lambda s: s._fresh_air_fan_speed,
         PropertyId.IECO: lambda s: (s._ieco_number, s._ieco),
         PropertyId.OUT_SILENT: lambda s: s._out_silent,
+        PropertyId.PROMPT_TONE: lambda s: s._beep_on,
         PropertyId.RATE_SELECT: lambda s: s._rate_select,
+        PropertyId.SOUND: lambda s: s._sound,
         PropertyId.SWING_LR_ANGLE: lambda s: s._horizontal_swing_angle,
         PropertyId.SWING_UD_ANGLE: lambda s: s._vertical_swing_angle,
-        PropertyId.PROMPT_TONE: lambda s: s._beep_on,
-        PropertyId.SOUND: lambda s: s._sound,
     }
 
     _SUPPORTED_CAPABILITY_OVERRIDES = {

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -817,6 +817,12 @@ class TestSetPropertiesCommand(unittest.TestCase):
             (PropertyId.BREEZE_CONTROL, 0x04): bytes([0x04]),
             (PropertyId.BREEZE_CONTROL, 0x00): bytes([0x00]),
 
+            # Sound/Prompt Tone: 0x01 - On, 0x00 - Off
+            (PropertyId.SOUND, True): bytes([0x01]),
+            (PropertyId.SOUND, False): bytes([0x00]),
+            (PropertyId.PROMPT_TONE, True): bytes([0x01]),
+            (PropertyId.PROMPT_TONE, False): bytes([0x00]),
+
             # IECO: 13 bytes ieco_frame, ieco_number, ieco_switch, ...
             (PropertyId.IECO, (1, True)): bytes([0, 1, 1]) + bytes(10),
             (PropertyId.IECO, (1, False)): bytes([0, 1, 0]) + bytes(10),
@@ -887,8 +893,11 @@ class TestPropertiesResponse(_TestResponseBase):
             (PropertyId.BREEZE_CONTROL, bytes([0x04])): 0x04,
             (PropertyId.BREEZE_CONTROL, bytes([0x00])): 0x00,
 
-            # Buzzer: Don't decode
-            (PropertyId.BUZZER, bytes([0x00])): None,
+            # Sound/Prompt Tone: 0x01 - On, 0x00 - Off
+            (PropertyId.SOUND, bytes([0x01])): True,
+            (PropertyId.SOUND, bytes([0x00])): False,
+            (PropertyId.PROMPT_TONE, bytes([0x01])): True,
+            (PropertyId.PROMPT_TONE, bytes([0x00])): False,
 
             # IECO: 2 bytes
             (PropertyId.IECO, bytes([0x00, 0x00])): False,
@@ -1000,8 +1009,8 @@ class TestPropertiesResponse(_TestResponseBase):
         # Assert response is a correct type
         self.assertEqual(type(resp), PropertiesResponse)
 
-        # Assert that the buzzer property is not decoded
-        self.assertIsNone(resp.get_property(PropertyId.BUZZER))
+        # Assert that the prompt tone property is decoded correctly
+        self.assertEqual(resp.get_property(PropertyId.PROMPT_TONE), False)
 
     def test_properties_execution_failed(self) -> None:
         """Test we error when decoding properties that had an execution error."""

--- a/msmart/device/AC/test_command.py
+++ b/msmart/device/AC/test_command.py
@@ -817,11 +817,11 @@ class TestSetPropertiesCommand(unittest.TestCase):
             (PropertyId.BREEZE_CONTROL, 0x04): bytes([0x04]),
             (PropertyId.BREEZE_CONTROL, 0x00): bytes([0x00]),
 
-            # Sound/Prompt Tone: 0x01 - On, 0x00 - Off
-            (PropertyId.SOUND, True): bytes([0x01]),
-            (PropertyId.SOUND, False): bytes([0x00]),
+            # Prompt Tone/Sound: 0x01 - On, 0x00 - Off
             (PropertyId.PROMPT_TONE, True): bytes([0x01]),
             (PropertyId.PROMPT_TONE, False): bytes([0x00]),
+            (PropertyId.SOUND, True): bytes([0x01]),
+            (PropertyId.SOUND, False): bytes([0x00]),
 
             # IECO: 13 bytes ieco_frame, ieco_number, ieco_switch, ...
             (PropertyId.IECO, (1, True)): bytes([0, 1, 1]) + bytes(10),
@@ -893,11 +893,11 @@ class TestPropertiesResponse(_TestResponseBase):
             (PropertyId.BREEZE_CONTROL, bytes([0x04])): 0x04,
             (PropertyId.BREEZE_CONTROL, bytes([0x00])): 0x00,
 
-            # Sound/Prompt Tone: 0x01 - On, 0x00 - Off
-            (PropertyId.SOUND, bytes([0x01])): True,
-            (PropertyId.SOUND, bytes([0x00])): False,
+            # Prompt Tone/Sound: 0x01 - On, 0x00 - Off
             (PropertyId.PROMPT_TONE, bytes([0x01])): True,
             (PropertyId.PROMPT_TONE, bytes([0x00])): False,
+            (PropertyId.SOUND, bytes([0x01])): True,
+            (PropertyId.SOUND, bytes([0x00])): False,
 
             # IECO: 2 bytes
             (PropertyId.IECO, bytes([0x00, 0x00])): False,


### PR DESCRIPTION
- Maps `PropertyId.SOUND` to `0x022C` (matches `buzzer_all` from midea-lan)
- Maps `PropertyId.PROMPT_TONE` to `0x001A` (matches `prompt_tone` from midea-lan)
- Updates encoding and decoding to correctly use `0x01` and `0x00` for these properties
- Updates `device.beep` to map to `PROMPT_TONE` so that applying changes triggers an acknowledgment beep (matching the V2 protocol behavior)
- Exposes a new `device.sound` property mapped to `SOUND` to allow toggling the AC's global buzzer setting
- Updates all corresponding capability mappings and unit tests

Regarding https://github.com/mill1000/midea-ac-py/issues/481

Original implementation: https://github.com/wuwentao/midea-lan/blob/main/midealan/devices/ac/message.py
