### PR TITLE
Add Midea C3 heat pump (0xC3) device support

### DIFF
--- a/msmart/base_device.py
+++ b/msmart/base_device.py
@@ -250,5 +250,9 @@ class Device():
             from msmart.device import CommercialAirConditioner
             return CommercialAirConditioner(**kwargs)
 
+        if type == DeviceType.HEAT_PUMP:
+            from msmart.device import HeatPump
+            return HeatPump(**kwargs)
+
         # Unknown type return generic device
         return Device(device_type=type, **kwargs)

--- a/msmart/const.py
+++ b/msmart/const.py
@@ -28,6 +28,7 @@ DEFAULT_CLOUD_REGION = "US"
 class DeviceType(IntEnum):
     AIR_CONDITIONER = 0xAC
     COMMERCIAL_AC = 0xCC
+    HEAT_PUMP = 0xC3
 
 
 class FrameType(IntEnum):

--- a/msmart/device/C3/command.py
+++ b/msmart/device/C3/command.py
@@ -1,0 +1,362 @@
+"""Command and repsonse messages for 0xC3 devices."""
+from __future__ import annotations
+
+import logging
+import struct
+from enum import IntEnum
+from typing import Union
+
+from msmart.const import DeviceType, FrameType
+from msmart.frame import Frame
+
+_LOGGER = logging.getLogger(__name__)
+
+# Useful acronyms
+# DHW - Domestic hot water
+# TBH - Tank booster heater
+# IBH - Internal backup heater
+
+
+class ControlType(IntEnum):
+    """Control message types."""
+    CONTROL_BASIC = 0x1
+    CONTROL_DAY_TIMER = 0x2
+    CONTROL_WEEKS_TIMER = 0x3
+    CONTROL_HOLIDAY_AWAY = 0x4
+    CONTROL_SILENCE = 0x05
+    CONTROL_HOLIDAY_HOME = 0x6
+    CONTROL_ECO = 0x7
+    CONTROL_INSTALL = 0x8
+    CONTROL_DISINFECT = 0x9
+
+
+class QueryType(IntEnum):
+    """Query message types."""
+    QUERY_BASIC = 0x1
+    QUERY_DAY_TIMER = 0x2
+    QUERY_WEEKS_TIMER = 0x3
+    QUERY_HOLIDAY_AWAY = 0x4
+    QUERY_SILENCE = 0x05
+    QUERY_HOLIDAY_HOME = 0x6
+    QUERY_ECO = 0x7
+    QUERY_INSTALL = 0x8
+    QUERY_DISINFECT = 0x9
+    QUERY_HMI_PARAMETERS = 0x0A
+    QUERY_UNIT_PARAMETERS = 0x10
+
+
+class ReportType(IntEnum):  # Ref: MSG_TYPE_UP
+    """Report message types."""
+    REPORT_BASIC = 0x1
+    REPORT_POWER3 = 0x3
+    REPORT_POWER4 = 0x4
+    REPORT_UNIT_PARAMETERS = 0x5
+
+
+class QueryCommand(Frame):
+    """Base class for query commands."""
+
+    def __init__(self, type: QueryType) -> None:
+        super().__init__(DeviceType.HEAT_PUMP, frame_type=FrameType.QUERY)
+
+        self._type = type
+
+    def tobytes(self) -> bytes:
+        return super().tobytes(bytes([
+            self._type
+        ]))
+
+
+class QueryBasicCommand(QueryCommand):
+    """Command to query basic device state."""
+
+    def __init__(self) -> None:
+        super().__init__(QueryType.QUERY_BASIC)
+
+
+class QueryEcoCommand(QueryCommand):
+    """Command to query ECO state."""
+
+    def __init__(self) -> None:
+        super().__init__(QueryType.QUERY_ECO)
+
+
+class QueryUnitParametersCommand(QueryCommand):
+    """Command to query unit parameters."""
+
+    def __init__(self) -> None:
+        super().__init__(QueryType.QUERY_UNIT_PARAMETERS)
+
+
+class ControlCommand(Frame):
+    """Base class for control commands."""
+
+    def __init__(self, type: ControlType) -> None:
+        super().__init__(DeviceType.HEAT_PUMP, frame_type=FrameType.CONTROL)
+
+        self._type = type
+
+
+class ControlBasicCommand(ControlCommand):
+    """Command to control basic device state."""
+
+    def __init__(self) -> None:
+        super().__init__(ControlType.CONTROL_BASIC)
+
+        self.zone1_power_state = False
+        self.zone2_power_state = False
+        self.dhw_power_state = False
+
+        self.run_mode = 0
+
+        self.zone1_target_temperature = 25
+        self.zone2_target_temperature = 25
+        self.dhw_target_temperature = 25
+        self.room_target_temperature = 25.0
+
+        self.zone1_curve_state = False
+        self.zone2_curve_state = False
+
+        self.tbh_state = False
+        self.dhw_fast_mode = False
+
+        # TODO "newfunction_en"
+        self.zone1_curve_type = 0
+        self.zone2_curve_type = 0
+
+    def tobytes(self) -> bytes:
+        payload = bytearray(10)
+
+        payload[0] = self._type
+
+        payload[1] |= 1 << 0 if self.zone1_power_state else 0
+        payload[1] |= 1 << 1 if self.zone2_power_state else 0
+        payload[1] |= 1 << 2 if self.dhw_power_state else 0
+
+        payload[2] = self.run_mode
+        payload[3] = self.zone1_target_temperature
+        payload[4] = self.zone2_target_temperature
+        payload[5] = self.dhw_target_temperature
+        payload[6] = int(self.room_target_temperature * 2)  # Convert ℃ to .5 ℃
+
+        payload[7] |= 1 << 0 if self.zone1_curve_state else 0
+        payload[7] |= 1 << 1 if self.zone2_curve_state else 0
+        payload[7] |= 1 << 2 if self.tbh_state else 0
+        payload[7] |= 1 << 3 if self.dhw_fast_mode else 0
+
+        # TODO newfunction_en
+        # payload[8] = self.zone1_curve_type
+        # payload[9] = self.zone2_curve_type
+
+        return super().tobytes(payload)
+
+
+class Response():
+    """Base class for responses."""
+
+    def __init__(self, frame: memoryview) -> None:
+
+        self._type = frame[10]
+        self._payload = bytes(frame[10:-1])
+
+    @property
+    def type(self) -> int:
+        """Type of the response."""
+        return self._type
+
+    @property
+    def payload(self) -> bytes:
+        """Payload portion of the response."""
+        return self._payload
+
+    @classmethod
+    def validate(cls, frame: memoryview) -> None:
+        """Validate the response."""
+        Frame.validate(frame, DeviceType.HEAT_PUMP)
+
+    @classmethod
+    def construct(cls, frame: bytes) -> Union[QueryBasicResponse, QueryUnitParametersResponse, ReportPower4Response, Response]:
+        """Build a response object from the frame and response type."""
+
+        # Build a memoryview of the frame for zero-copy slicing
+        with memoryview(frame) as frame_mv:
+            # Ensure frame is valid before parsing
+            Response.validate(frame_mv)
+
+            # Parse frame depending on id
+            frame_type = frame_mv[9]
+            type = frame_mv[10]
+            if ((frame_type == FrameType.QUERY and type == QueryType.QUERY_BASIC) or
+                (frame_type == FrameType.CONTROL and type == ControlType.CONTROL_BASIC)):
+                return QueryBasicResponse(frame_mv)
+            elif frame_type == FrameType.QUERY and type == QueryType.QUERY_UNIT_PARAMETERS:
+                return QueryUnitParametersResponse(frame_mv)
+            elif frame_type == FrameType.REPORT and type == ReportType.REPORT_POWER4:
+                return ReportPower4Response(frame_mv)
+            else:
+                return Response(frame_mv)
+
+
+class QueryBasicResponse(Response):
+    """Response to basic query."""
+
+    def __init__(self, frame: memoryview) -> None:
+        super().__init__(frame)
+
+        _LOGGER.debug("Query basic response payload: %s", self.payload.hex())
+
+        with memoryview(self.payload) as payload:
+            self._parse(payload)
+
+    def _parse(self, payload: memoryview) -> None:
+
+        self.zone1_power_state = bool(payload[1] & 0x01)
+        self.zone2_power_state = bool(payload[1] & 0x02)
+        self.dhw_power_state = bool(payload[1] & 0x04)
+        self.zone1_curve_state = bool(payload[1] & 0x08)
+        self.zone2_curve_state = bool(payload[1] & 0x10)
+        self.tbh_state = bool(payload[1] & 0x40)  # Ref: forcetbh_state
+        self.dhw_fast_mode = bool(payload[1] & 0x40) # Ref: fastdhw_state
+        # self.remote_onoff = bool(payload[1] & 0x80) # TODO never referenced in ref
+
+        self.heat_enable = bool(payload[2] & 0x01)
+        self.cool_enable = bool(payload[2] & 0x02)
+        self.dhw_enable = bool(payload[2] & 0x04)
+        self.zone2_enable = bool(payload[2] & 0x08)  # Ref: double_zone_enable
+
+        # 0 - Air, 1 - Water
+        self.zone1_temperature_type = int(bool(payload[2] & 0x10))
+        self.zone2_temperature_type = int(bool(payload[2] & 0x20))
+
+        # Ref: room_thermalen_state, room_thermalmode_state
+        self.room_thermostat_power_state = bool(payload[2] & 0x40)
+        self.room_thermostat_enable = bool(payload[2] & 0x80)
+
+        self.time_set_state = bool(payload[3] & 0x01)
+        self.silence_on_state = bool(payload[3] & 0x02)
+        self.holiday_on_state = bool(payload[3] & 0x04)
+        self.eco_on_state = bool(payload[3] & 0x08)
+
+        self.zone1_terminal_type = (payload[3] & 0x30) >> 4
+        self.zone2_terminal_type = (payload[3] & 0xC0) >> 6
+
+        self.run_mode = payload[4]  # Ref: run_mode_set
+        self.run_mode_under_auto = payload[5]  # Ref: runmode_under_auto
+
+        self.zone1_target_temperature = payload[6]  # Ref: zone1_temp_set
+        self.zone2_target_temperature = payload[7]  # Ref: zone2_temp_set
+        self.dhw_target_temperature = payload[8]  # Ref: dhw_temp_set
+        self.room_target_temperature = payload[9]/2  # .5 ℃ Ref: room_temp_set
+
+        self.zone1_heat_max_temperature = payload[10]
+        self.zone1_heat_min_temperature = payload[11]
+        self.zone1_cool_max_temperature = payload[12]
+        self.zone1_cool_min_temperature = payload[13]
+
+        self.zone2_heat_max_temperature = payload[14]
+        self.zone2_heat_min_temperature = payload[15]
+        self.zone2_cool_max_temperature = payload[16]
+        self.zone2_cool_min_temperature = payload[17]
+
+        self.room_max_temperature = payload[18]/2  # .5 ℃
+        self.room_min_temperature = payload[19]/2  # .5 ℃
+
+        self.dhw_max_temperature = payload[20]
+        self.dhw_min_temperature = payload[21]
+
+        # Actual tank temperature in ℃
+        # Ref: tank_actual_temp
+        # Values >= 0xF0 are error/sensor-not-connected codes
+        self.tank_temperature = payload[22] if payload[22] < 0xF0 else None
+
+        self.error_code = payload[23]
+
+        # Ref: boostertbh_en
+        self.tbh_enable = bool(payload[24] & 0x80)
+
+        if len(payload) > 25:
+            # TODO newfunction_en = True
+            self.zone1_curve_type = payload[25]
+            self.zone2_curve_type = payload[26]
+
+
+class ReportPower4Response(Response):
+    """Unsolicited report of POWER4."""
+
+    def __init__(self, frame: memoryview) -> None:
+        super().__init__(frame)
+
+        _LOGGER.debug("Power4 report payload: %s", self.payload.hex())
+
+        with memoryview(self.payload) as payload:
+            self._parse(payload)
+
+    def _parse(self, payload: memoryview) -> None:
+
+        # Local function to convert byte to signed int
+        def signed_int(data) -> int:
+            return struct.unpack("b", data)[0]
+
+        # TODO do these indicate current activity, or power state
+        self.heat_active = bool(payload[1] & 0x01)  # Ref: isheatrun0
+        self.cool_active = bool(payload[1] & 0x02)  # Ref: iscoolrun0
+        self.dhw_active = bool(payload[1] & 0x04)  # Ref: isdhwrun0
+        self.tbh_active = bool(payload[1] & 0x08)  # Ref: istbhrun0
+
+        # TODO isibhrun0, issmartgrid0m, ishighprices0, isbottomprices0
+
+        # Ref: totalelectricity0
+        self.electric_power = struct.unpack(">I", payload[2:6])[0]
+        # Ref: totalthermal0
+        self.thermal_power = struct.unpack(">I", payload[6:10])[0]
+
+        # TODO water and air temperatures may need to be checked for validity
+        self.outdoor_air_temperature = signed_int(payload[10:11])  # Ref: t4
+
+        self.zone1_target_temperature = payload[11]
+        self.zone2_target_temperature = payload[12]
+
+        self.water_tank_temperature = payload[13]  # Ref: t5s
+        # TODO payload[14] Ref: tas
+
+        # TODO What does online mean?
+        self.online = bool(payload[17] & 0x01)  # Ref: isonline0
+
+        # Bytes 19 - 153 contain run status and energy 1 - 15
+
+        # Bytes 154, 155 contain run status of ibh2 0-15
+
+        self.voltage = payload[156]  # Ref: voltage0
+        # voltage0-15 bytes 157-171
+
+        # TODO
+        # self.ibh1_power = payload[172] # Ref: power_ibh1
+        # self.ibh2_power = payload[173] # Ref: power_ibh1
+        # self.tbh_power = payload[174] # Ref: power_ibh1
+
+
+class QueryUnitParametersResponse(Response):
+    """Response to unit parameters query."""
+
+    def __init__(self, frame: memoryview) -> None:
+        super().__init__(frame)
+
+        _LOGGER.debug("Query unit parameters response payload: %s",
+                      self.payload.hex())
+
+        with memoryview(self.payload) as payload:
+            self._parse(payload)
+
+    def _parse(self, payload: memoryview) -> None:
+
+        # There are many fields of this response that are unused and thus not parsed
+
+        # Local function to convert byte to signed int
+        def signed_int(data) -> int:
+            return struct.unpack("b", data)[0]
+
+        self.outdoor_temperature = signed_int(payload[8:9])  # Ref: tempT4
+        self.water_temperature_2 = signed_int(payload[11:12])  # Ref: tempTwout
+        # Referenced in JS w/o friendly name
+        self.temp_t5 = signed_int(payload[38:39])
+        self.room_temperature = signed_int(payload[39:40])  # Ref: tempTa

--- a/msmart/device/C3/device.py
+++ b/msmart/device/C3/device.py
@@ -1,0 +1,446 @@
+"""Module for Midea 0xC3 devices."""
+from __future__ import annotations
+
+import logging
+from enum import IntEnum
+from typing import Optional, Union, cast
+
+from msmart.base_device import Device
+from msmart.const import DeviceType
+from msmart.frame import InvalidFrameException
+from msmart.utils import MideaIntEnum
+
+from .command import (ControlBasicCommand, QueryBasicCommand,
+                      QueryBasicResponse, QueryUnitParametersCommand,
+                      QueryUnitParametersResponse, ReportPower4Response,
+                      Response)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HeatPump(Device):
+    """Device class for heat pump (0xC3) devices."""
+
+    class RunMode(MideaIntEnum):
+        """Heat pump run/operation modes."""
+        # TODO is 0 off?
+        AUTO = 1
+        COOL = 2
+        HEAT = 3
+        DHW = 5  # TODO not in Lua?
+
+        DEFAULT = AUTO
+
+    class TerminalType(IntEnum):
+        """Zone "terminal" type."""
+        FAN_COIL = 0
+        FLOOR_HEAT = 1
+        RADIATOR = 2
+
+    class TemperatureType(IntEnum):
+        """Zone temperature type."""
+        AIR = 0
+        WATER = 1
+
+    class Zone:
+        """A zone within the heat pump system."""
+
+        def __init__(self) -> None:
+            self._power_state = False
+            self._curve_state = False
+            self._temperature_type = HeatPump.TemperatureType.AIR
+            self._terminal_type = HeatPump.TerminalType.FAN_COIL
+
+            self._target_temperature = 25
+
+            self._min_heat_temperature = 25
+            self._max_heat_temperature = 55
+
+            self._min_cool_temperature = 5
+            self._max_cool_temperature = 25
+
+        @property
+        def power_state(self) -> bool:
+            """Power state of the zone."""
+            return self._power_state
+
+        @power_state.setter
+        def power_state(self, state: bool) -> None:
+            self._power_state = state
+
+        @property
+        def curve_state(self) -> bool:
+            """Curve state of the zone."""
+            return self._curve_state
+
+        @curve_state.setter
+        def curve_state(self, state: bool) -> None:
+            self._curve_state = state
+
+        @property
+        def target_temperature(self) -> int:
+            """Target temperature of the zone."""
+            return self._target_temperature
+
+        @target_temperature.setter
+        def target_temperature(self, temperature_celsius: int) -> None:
+            self._target_temperature = temperature_celsius
+
+        @property
+        def temperature_type(self) -> HeatPump.TemperatureType:
+            """Temperature type of the zone."""
+            return self._temperature_type
+
+        @property
+        def terminal_type(self) -> HeatPump.TerminalType:
+            """Terminal type of the zone."""
+            return self._terminal_type
+
+    def __init__(self, ip: str, device_id: int,  port: int, **kwargs) -> None:
+        # Remove possible duplicate device_type kwarg
+        kwargs.pop("device_type", None)
+
+        super().__init__(ip=ip, port=port, device_id=device_id,
+                         device_type=DeviceType.HEAT_PUMP, **kwargs)
+
+        self._run_mode = HeatPump.RunMode.DEFAULT
+        self._heat_enable = False
+        self._cool_enable = False
+
+        self._zone1 = HeatPump.Zone()
+        self._zone2 = None
+
+        # Domestic hot water
+        self._dhw_enable = False
+        self._dhw_power_state = False
+        self._dhw_target_temperature = 25
+        self._dhw_min_temperature = 20
+        self._dhw_max_temperature = 60
+        self._dhw_fast_mode = False
+
+        # Room thermostat
+        self._room_thermostat_enable = False
+        self._room_thermostat_power_state = False
+        self._room_target_temperature = 25.0
+        self._room_min_temperature = 17.0
+        self._room_max_temperature = 30.0
+
+        # Tank booster heater
+        self._tbh_enable = False
+        self._tbh_power_state = False
+        
+        # Sensors
+        self._tank_temperature = None
+        self._outdoor_temperature = None
+
+        self._electric_power = None
+        self._thermal_power = None
+        self._voltage = None
+
+    def _update_state(self, res: Union[QueryBasicResponse, QueryUnitParametersResponse, ReportPower4Response]) -> None:
+        """Update local device state from device responses."""
+
+        if isinstance(res, QueryBasicResponse):
+            self._run_mode = cast(
+                HeatPump.RunMode, HeatPump.RunMode.get_from_value(res.run_mode))
+            # TODO Run mode in auto?
+            self._heat_enable = res.heat_enable
+            self._cool_enable = res.cool_enable
+
+            # Create zone 2 if supported
+            if res.zone2_enable and self._zone2 is None:
+                self._zone2 = HeatPump.Zone()
+
+            for i, zone in enumerate([self._zone1, self._zone2], start=1):
+
+                # Skip nonexistent zones
+                if zone is None:
+                    continue
+
+                zone._power_state = getattr(res, f"zone{i}_power_state")
+                zone._curve_state = getattr(res, f"zone{i}_curve_state")
+                zone._temperature_type = HeatPump.TemperatureType(
+                    getattr(res, f"zone{i}_temperature_type"))
+                zone._terminal_type = HeatPump.TerminalType(getattr(
+                    res, f"zone{i}_terminal_type"))
+
+                zone._target_temperature = getattr(
+                    res, f"zone{i}_target_temperature")
+
+                zone._min_heat_temperature = getattr(
+                    res, f"zone{i}_heat_min_temperature")
+                zone._max_heat_temperature = getattr(
+                    res, f"zone{i}_heat_max_temperature")
+
+                zone._min_cool_temperature = getattr(
+                    res, f"zone{i}_cool_min_temperature")
+                zone._max_cool_temperature = getattr(
+                    res, f"zone{i}_cool_max_temperature")
+
+            self._dhw_enable = res.dhw_enable
+            self._dhw_power_state = res.dhw_power_state
+            self._dhw_target_temperature = res.dhw_target_temperature
+            self._dhw_min_temperature = res.dhw_min_temperature
+            self._dhw_max_temperature = res.dhw_max_temperature
+            self._dhw_fast_mode = res.dhw_fast_mode
+
+            self._room_thermostat_enable = res.room_thermostat_enable
+            self._room_thermostat_power_state = res.room_thermostat_power_state
+            self._room_target_temperature = res.room_target_temperature
+            self._room_min_temperature = res.room_min_temperature
+            self._room_max_temperature = res.room_max_temperature
+
+            self._tbh_enable = res.tbh_enable
+            self._tbh_power_state = res.tbh_state
+
+            # TODO time set state, silence state, holiday state, eco state
+            # TODO error code
+
+            self._tank_temperature = res.tank_temperature
+
+        elif isinstance(res, QueryUnitParametersResponse):
+
+            self._outdoor_temperature = res.outdoor_temperature
+            if res.water_temperature_2 is not None:
+                self._tank_temperature = res.water_temperature_2
+
+        elif isinstance(res, ReportPower4Response):
+
+            self._electric_power = res.electric_power
+            self._thermal_power = res.thermal_power
+            self._outdoor_temperature = res.outdoor_air_temperature
+            self._voltage = res.voltage
+
+    async def _send_command_parse_responses(self, command) -> None:
+        """Send a command and parse any responses."""
+
+        responses = await super()._send_command(command)
+
+        # No response from device
+        if responses is None:
+            self._online = False
+            return
+
+        # Device is online if we received any response
+        self._online = True
+
+        for data in responses:
+            try:
+                # Construct response from data
+                response = Response.construct(data)
+            except InvalidFrameException as e:
+                _LOGGER.error(e)
+                continue
+
+            # Device is supported if we can process a response
+            self._supported = True
+
+            # Parse responses as needed
+            if isinstance(response, (QueryBasicResponse, QueryUnitParametersResponse, ReportPower4Response)):
+                self._update_state(response)
+            else:
+                _LOGGER.debug("Ignored unknown response from %s:%d: %s",
+                              self.ip, self.port, response.payload.hex())
+
+    async def refresh(self) -> None:
+        """Refresh the local copy of the device state."""
+
+        # Query basic state (always supported)
+        await self._send_command_parse_responses(QueryBasicCommand())
+
+        # Query unit parameters for outdoor temperature; not supported on all relay paths
+        try:
+            await self._send_command_parse_responses(QueryUnitParametersCommand())
+        except Exception:
+            _LOGGER.debug("Unit parameters query not available for %s:%d.", self.ip, self.port)
+
+    async def apply(self) -> None:
+        """Apply the local state to the device."""
+
+        cmd = ControlBasicCommand()
+        cmd.run_mode = self._run_mode
+
+        cmd.zone1_power_state = self._zone1.power_state
+        cmd.zone1_target_temperature = self._zone1.target_temperature
+        cmd.zone1_curve_state = self._zone1.curve_state
+
+        if self._zone2:
+            cmd.zone2_power_state = self._zone2.power_state
+            cmd.zone2_target_temperature = self._zone2.target_temperature
+            cmd.zone2_curve_state = self._zone2.curve_state
+
+        cmd.dhw_power_state = self._dhw_power_state
+        cmd.dhw_target_temperature = self._dhw_target_temperature
+        cmd.dhw_fast_mode = self._dhw_fast_mode
+
+        cmd.room_target_temperature = self._room_target_temperature
+
+        cmd.tbh_state = self._tbh_power_state
+
+        await self._send_command_parse_responses(cmd)
+
+    @property
+    def run_mode(self) -> HeatPump.RunMode:
+        """Current run mode."""
+        return self._run_mode
+
+    @run_mode.setter
+    def run_mode(self, mode: HeatPump.RunMode) -> None:
+        self._run_mode = mode
+
+    @property
+    def tbh_power_state(self) -> int:
+        """Power state of internal backup heater."""
+        return self._tbh_power_state
+
+    @tbh_power_state.setter
+    def tbh_power_state(self, state: bool) -> None:
+        self._tbh_power_state = state
+
+    @property
+    def zone1(self) -> HeatPump.Zone:
+        """Zone 1"""
+        return self._zone1
+
+    @property
+    def zone1_power_state(self) -> bool:
+        """Power state of zone 1."""
+        return self._zone1.power_state
+
+    @zone1_power_state.setter
+    def zone1_power_state(self, state: bool) -> None:
+        self._zone1.power_state = state
+
+    @property
+    def zone1_target_temperature(self) -> int:
+        """Target temperature of zone 1."""
+        return self._zone1.target_temperature
+
+    @zone1_target_temperature.setter
+    def zone1_target_temperature(self, temperature_celsius: int) -> None:
+        self._zone1.target_temperature = temperature_celsius
+
+    @property
+    def zone1_min_heat_temperature(self) -> int:
+        """Minimum heat target temperature for zone 1."""
+        return self._zone1._min_heat_temperature
+
+    @property
+    def zone1_max_heat_temperature(self) -> int:
+        """Maximum heat target temperature for zone 1."""
+        return self._zone1._max_heat_temperature
+
+    @property
+    def zone1_min_cool_temperature(self) -> int:
+        """Minimum cool target temperature for zone 1."""
+        return self._zone1._min_cool_temperature
+
+    @property
+    def zone1_max_cool_temperature(self) -> int:
+        """Maximum cool target temperature for zone 1."""
+        return self._zone1._max_cool_temperature
+
+    @property
+    def zone2(self) -> Optional[HeatPump.Zone]:
+        """Zone 2 if supported"""
+        return self._zone2
+
+    @property
+    def zone2_power_state(self) -> Optional[bool]:
+        """Power state of zone 2."""
+        return self._zone2.power_state if self._zone2 else None
+
+    @zone2_power_state.setter
+    def zone2_power_state(self, state: bool) -> None:
+        if self._zone2:
+            self._zone2.power_state = state
+
+    @property
+    def zone2_target_temperature(self) -> Optional[int]:
+        """Target temperature of zone 2."""
+        return self._zone2.target_temperature if self._zone2 else None
+
+    @zone2_target_temperature.setter
+    def zone2_target_temperature(self, temperature_celsius: int) -> None:
+        if self._zone2:
+            self._zone2.target_temperature = temperature_celsius
+
+    @property
+    def dhw_power_state(self) -> int:
+        """Power state of domestic hot water."""
+        return self._dhw_power_state
+
+    @dhw_power_state.setter
+    def dhw_power_state(self, state: bool) -> None:
+        self._dhw_power_state = state
+
+    @property
+    def dhw_fast_mode(self) -> int:
+        """State of fast DHW mode."""
+        return self._dhw_fast_mode
+
+    @dhw_fast_mode.setter
+    def dhw_fast_mode(self, state: bool) -> None:
+        self._dhw_fast_mode = state
+
+    @property
+    def dhw_target_temperature(self) -> int:
+        """Target domestic hot water temperature."""
+        return self._dhw_target_temperature
+
+    @dhw_target_temperature.setter
+    def dhw_target_temperature(self, temperature_celsius: int) -> None:
+        self._dhw_target_temperature = temperature_celsius
+
+    @property
+    def dhw_min_temperature(self) -> int:
+        """Minimum target domestic hot water temperature."""
+        return self._dhw_min_temperature
+
+    @property
+    def dhw_max_temperature(self) -> int:
+        """Maximum target domestic hot water temperature."""
+        return self._dhw_max_temperature
+
+    @property
+    def water_temperature(self) -> Optional[int]:
+        """Current water tank temperature."""
+        return self._tank_temperature
+
+    @property
+    def outdoor_temperature(self) -> Optional[int]:
+        """Current outdoor temperature."""
+        return self._outdoor_temperature
+
+    @property
+    def electric_power(self) -> Optional[int]:
+        """Consumed electric power."""
+        return self._electric_power
+
+    @property
+    def thermal_power(self) -> Optional[int]:
+        """Generated thermal power."""
+        return self._thermal_power
+
+    @property
+    def voltage(self) -> Optional[int]:
+        """Current voltage of the mains."""
+        return self._voltage
+
+    def to_dict(self) -> dict:
+        return {**super().to_dict(), **{
+            "mode": self._run_mode,
+            "zone1_power": self.zone1.power_state,
+            "zone1_target_temperature": self.zone1.target_temperature,
+            "zone2_power": self.zone2.power_state if self.zone2 else None,
+            "zone2_target_temperature": self.zone2.target_temperature if self.zone2 else None,
+            "dhw_power": self._dhw_power_state,
+            "dhw_target_temperature": self.dhw_target_temperature,
+            "dhw_fast_mode": self.dhw_fast_mode,
+            "tbh_power": self.tbh_power_state,
+            "water_temperature": self.water_temperature,
+            "outdoor_temperature": self.outdoor_temperature,
+            "electric_power": self.electric_power,
+            "thermal_power": self.thermal_power,
+            "voltage": self.voltage,
+        }}

--- a/msmart/device/C3/test_command.py
+++ b/msmart/device/C3/test_command.py
@@ -1,0 +1,151 @@
+import unittest
+from typing import Union, cast
+
+from msmart.const import FrameType
+
+from .command import (ControlBasicCommand, ControlType, QueryBasicCommand,
+                      QueryBasicResponse, QueryType, ReportPower4Response,
+                      Response)
+
+
+class _TestResponseBase(unittest.TestCase):
+    """Base class that provides some common methods for derived classes."""
+
+    def assertHasAttr(self, obj, attr) -> None:
+        """Assert that an object has an attribute."""
+        self.assertTrue(hasattr(obj, attr),
+                        msg=f"Object {obj} lacks attribute '{attr}'.")
+
+    def _test_build_response(self, msg) -> Union[QueryBasicResponse, Response]:
+        """Build a response from the frame and assert it exists."""
+        resp = Response.construct(msg)
+        self.assertIsNotNone(resp)
+        return resp
+
+    def _test_check_attributes(self, obj, expected_attrs) -> None:
+        """Assert that an object has all expected attributes."""
+        for attr in expected_attrs:
+            self.assertHasAttr(obj, attr)
+
+
+class TestQueryBasicResponse(_TestResponseBase):
+    """Test basic query response messages."""
+
+    # Attributes expected in query response objects
+    EXPECTED_ATTRS = ["zone1_power_state", "zone2_power_state",
+                      "dhw_power_state",
+                      "zone1_curve_state", "zone2_curve_state",
+                      "tbh_state", "dhw_fast_mode",
+                      "heat_enable", "cool_enable", "dhw_enable",
+                      "zone2_enable",
+                      "zone1_temperature_type", "zone2_temperature_type",
+                      "room_thermostat_power_state", "room_thermostat_enable",
+                      "time_set_state", "silence_on_state", "holiday_on_state", "eco_on_state",
+                      "zone1_terminal_type", "zone2_terminal_type",
+                      "run_mode", "run_mode_under_auto",
+                      "zone1_target_temperature", "zone2_target_temperature",
+                      "dhw_target_temperature", "room_target_temperature",
+                      "zone1_heat_max_temperature", "zone1_heat_min_temperature",
+                      "zone1_cool_max_temperature", "zone1_cool_min_temperature",
+                      "zone2_heat_max_temperature", "zone2_heat_min_temperature",
+                      "zone2_cool_max_temperature", "zone2_cool_min_temperature",
+                      "room_max_temperature", "room_min_temperature",
+                      "dhw_max_temperature", "dhw_min_temperature",
+                      "tank_temperature", "error_code", "tbh_enable"
+                      ]
+
+    def _test_response(self, msg) -> QueryBasicResponse:
+        resp = self._test_build_response(msg)
+        self._test_check_attributes(resp, self.EXPECTED_ATTRS)
+        return cast(QueryBasicResponse, resp)
+
+    def test_message(self) -> None:
+        # https://github.com/mill1000/midea-msmart/issues/107#issuecomment-1925457917
+        # Response from basic query command
+        TEST_MESSAGE = bytes.fromhex(
+            "aa23c300000000000003010517a10303191e143037191905371919053c223c142200002c")
+        resp = self._test_response(TEST_MESSAGE)
+
+        # Assert response is a state response
+        self.assertEqual(type(resp), QueryBasicResponse)
+
+
+class TestPower4Response(_TestResponseBase):
+    """Test POWER4 report messages."""
+
+    # Attributes expected in state response objects
+    EXPECTED_ATTRS = ["heat_active", "cool_active",
+                      "dhw_active", "tbh_active",
+                      "electric_power", "thermal_power",
+                      "outdoor_air_temperature",
+                      "zone1_target_temperature", "zone2_target_temperature",
+                      "water_tank_temperature",
+                      "online", "voltage"
+                      ]
+
+    def _test_response(self, msg) -> ReportPower4Response:
+        resp = self._test_build_response(msg)
+        self._test_check_attributes(resp, self.EXPECTED_ATTRS)
+        return cast(ReportPower4Response, resp)
+
+    def test_message(self) -> None:
+        # https://github.com/mill1000/midea-msmart/issues/107#issuecomment-1962036384
+        # Unsolicited report with POWER4 payload
+        TEST_MESSAGE = bytes.fromhex(
+            "aab9c3000000000000040400000012fc000023aa0b201e2930ffff01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e10000000000000000000000000000000000140b")
+        resp = self._test_response(TEST_MESSAGE)
+
+        # Assert response is a state response
+        self.assertEqual(type(resp), ReportPower4Response)
+
+        self.assertEqual(resp.electric_power, 4860)
+        self.assertEqual(resp.thermal_power, 9130)
+
+        self.assertEqual(resp.outdoor_air_temperature, 11)
+        self.assertEqual(resp.water_tank_temperature, 41)
+
+        self.assertEqual(resp.voltage, 225)
+
+
+class TestCommands(unittest.TestCase):
+    """Test basic command messages."""
+
+    def test_control_basic(self) -> None:
+        """Test that basic control fields are correct."""
+
+        # Build command
+        command = ControlBasicCommand()
+
+        # Fetch frame
+        frame = command.tobytes()
+
+        # Check length
+        self.assertEqual(frame[1], 0x14)
+
+        # Check frame type
+        self.assertEqual(frame[9], FrameType.CONTROL)
+
+        # Check control type
+        self.assertEqual(frame[10], ControlType.CONTROL_BASIC)
+
+    def test_query_basic(self) -> None:
+        """Test that basic query fields are correct."""
+
+        # Build command
+        command = QueryBasicCommand()
+
+        # Fetch frame
+        frame = command.tobytes()
+
+        # Check length
+        self.assertEqual(frame[1], 0x0B)
+
+        # Check frame type
+        self.assertEqual(frame[9], FrameType.QUERY)
+
+        # Check control type
+        self.assertEqual(frame[10], QueryType.QUERY_BASIC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/msmart/device/C3/test_device.py
+++ b/msmart/device/C3/test_device.py
@@ -1,0 +1,33 @@
+import unittest
+from typing import Union, cast
+
+from .command import QueryBasicResponse, Response
+from .device import HeatPump as HP
+
+
+class TestUpdateStateFromResponse(unittest.TestCase):
+    """Test updating device state from responses."""
+
+    def test_message(self) -> None:
+        """Test parsing of QueryBasicResponse into device state."""
+
+        # https://github.com/mill1000/midea-msmart/issues/107#issuecomment-1925457917
+        # Response from basic query command
+        TEST_MESSAGE = bytes.fromhex(
+            "aa23c300000000000003010517a10303191e143037191905371919053c223c142200002c")
+
+        resp = Response.construct(TEST_MESSAGE)
+        self.assertIsNotNone(resp)
+
+        # Assert response is a state response
+        self.assertEqual(type(resp), QueryBasicResponse)
+
+        # Create a dummy device and update the state
+        device = HP(0, 0, 0)
+        device._update_state(cast(QueryBasicResponse, resp))
+
+        # Assert on some properties here
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/msmart/device/__init__.py
+++ b/msmart/device/__init__.py
@@ -1,4 +1,5 @@
 from msmart.base_device import Device
 
 from .AC.device import AirConditioner
+from .C3.device import HeatPump
 from .CC.device import CommercialAirConditioner


### PR DESCRIPTION
## Summary

Follow-up to #262, reworked along the lines you suggested there: **no cloud code in the library**.

- Add `DeviceType.HEAT_PUMP = 0xC3`
- Add `HeatPump` device class (`msmart/device/C3/`): zone 1/zone 2, run modes (AUTO/HEAT/COOL/DHW), DHW, query/control command parsing, unit tests
- `Device.construct()` support for `HEAT_PUMP`

That's it — ~1000 lines of device code, rebased on current `main`.

## How it is used

C3 units refuse LAN V3 authentication (error 3004), so the cloud relay now lives in a small **separate service** ([midea-relay](https://github.com/xelhark/home-assistant-infra/tree/main/midea-relay)) that presents itself as a plain **V2 LAN device**: it answers the UDP discovery probe with the real device id/type/sn and accepts V2 (`5A5A`) packets on TCP 6444, forwarding the inner frames through `/v1/appliance/transparent/send`. As far as msmart-ng is concerned it is just another V2 device — `Discover.discover_single(<relay ip>)` returns a `HeatPump`, no token/key involved.

## Test plan

- [x] `msmart/device/C3` unit tests pass; the rest of the suite matches `main` (same network-dependent failures)
- [x] Discovery + query/control round-trip verified against a real C3 (device id 42880953506840) through the relay, integrated in Home Assistant (midea-ac-py fork)

Known limitation (unchanged from #262): the unit-parameters query (outdoor temperature, power) is answered with cloud error 3176 through the relay path, so those values are unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)